### PR TITLE
Fix squished window controls

### DIFF
--- a/styles/Frame.module.css
+++ b/styles/Frame.module.css
@@ -48,7 +48,7 @@
   align-items: center;
   padding: 0 16px;
   grid-gap: 12px;
-  grid-template-columns: 45px 1fr 45px;
+  grid-template-columns: 48px 1fr 48px;
 }
 
 .controls {


### PR DESCRIPTION
![CleanShot 2024-02-27 at 22 55 45@2x](https://github.com/raycast/ray-so/assets/2223418/7b514e84-a7d1-4f01-ac13-7c2b02797cb3)

Grid columns were too small leading to oval shapes for the window controls