### PR TITLE
Fix collapsing line breaks on Safari

### DIFF
--- a/components/HighlightedCode.tsx
+++ b/components/HighlightedCode.tsx
@@ -23,7 +23,7 @@ const HighlightedCode: React.FC<PropTypes> = ({ selectedLanguage, code }) => {
 
   const preView = useMemo(
     () => (
-      <div
+      <pre
         className={classNames(styles.formatted, "hljs")}
         dangerouslySetInnerHTML={{
           __html: html,


### PR DESCRIPTION
Fix exported screenshots having collapsed whitespace/line breaks when using Safari. Safari doesn't handle this correctly unless the code is wrapped in a `<pre />` tag… 🤦 

| Before | After |
|----------|----------|
| ![ray-so-export-32](https://github.com/raycast/ray-so/assets/2223418/49b4acac-50f5-46b4-ac88-2340fee50b97) | ![ray-so-export (7)](https://github.com/raycast/ray-so/assets/2223418/7aac4075-f082-4f0e-9945-ee1549f0e14f) |