### PR TITLE
Remove frame shadow if no background

### DIFF
--- a/components/Frame.tsx
+++ b/components/Frame.tsx
@@ -36,7 +36,8 @@ const Frame: React.FC = () => {
           {!showBackground && <div data-ignore-in-export className={styles.noBackground}></div>}
           <div
             className={classNames(styles.window, {
-              [styles.withShadow]: !isSafari,
+              [styles.withBorder]: !isSafari,
+              [styles.withShadow]: !isSafari && showBackground,
             })}
           >
             <div className={styles.header}>

--- a/styles/Frame.module.css
+++ b/styles/Frame.module.css
@@ -34,6 +34,11 @@
   background: var(--frame-background);
   transition: all ease 0.3s;
 
+  &.withBorder {
+    border: none;
+    box-shadow: 0 0 0 1px var(--frame-highlight-border), 0 0 0 1.5px var(--frame-shadow-border);
+  }
+
   &.withShadow {
     border: none;
     box-shadow: 0 0 0 1px var(--frame-highlight-border), 0 0 0 1.5px var(--frame-shadow-border),


### PR DESCRIPTION
Including the frame shadow on images without background doesn't look good as the shadow will always be "cut-off" due to the canvas size. Since padding is customizable it doesn't make sense to force the minimum size to shadow size. This pr removes the shadow completely if background is disabled.

![CleanShot 2024-02-29 at 18 26 38@2x](https://github.com/raycast/ray-so/assets/2223418/90f996fb-e7e0-4196-a2c2-7da78388c317)
