### PR TITLE
Add Github source code links to navigation layouts

### DIFF
--- a/app/(navigation)/(code)/code.tsx
+++ b/app/(navigation)/(code)/code.tsx
@@ -20,7 +20,7 @@ import { LANGUAGES } from "./util/languages";
 import tailwindLight from "./assets/tailwind/light.json";
 import tailwindDark from "./assets/tailwind/dark.json";
 import ExportButton from "./components/ExportButton";
-import { SpeechBubbleIcon } from "@raycast/icons";
+import { SpeechBubbleIcon, BrandGithubIcon } from "@raycast/icons";
 import { Button } from "@/components/button";
 import { NavigationActions } from "@/components/navigation";
 
@@ -45,6 +45,11 @@ export function Code() {
             <Button variant="transparent" asChild>
               <a href="mailto:feedback+rayso@raycast.com">
                 <SpeechBubbleIcon className="w-4 h-4" /> Send Feedback
+              </a>
+            </Button>
+            <Button variant="transparent" asChild>
+              <a href="https://github.com/raycast/ray-so" target="_blank">
+                <BrandGithubIcon className="w-4 h-4" /> Source Code
               </a>
             </Button>
             <KeyboardShortcutsPanel />

--- a/app/(navigation)/icon/icon-generator.tsx
+++ b/app/(navigation)/icon/icon-generator.tsx
@@ -30,6 +30,7 @@ import {
   LinkIcon,
   BrushIcon,
   SpeechBubbleIcon,
+  BrandGithubIcon,
   MagnifyingGlassIcon,
 } from "@raycast/icons";
 
@@ -825,10 +826,15 @@ export const IconGenerator = () => {
             </Button>
           </div>
           <div className="sm:flex gap-2 hidden">
-            <div className="xl:flex gap-2 hidden">
+            <div className="2xl:flex gap-2 hidden">
               <Button variant="transparent" asChild>
                 <a href={`mailto:${FEEDBACK_EMAIL}?subject=Icon`}>
                   <SpeechBubbleIcon className="w-4 h-4" /> Send Feedback
+                </a>
+              </Button>
+              <Button variant="transparent" asChild>
+                <a href="https://github.com/raycast/ray-so" target="_blank">
+                  <BrandGithubIcon className="w-4 h-4" /> Source Code
                 </a>
               </Button>
 

--- a/app/(navigation)/themes/layout.tsx
+++ b/app/(navigation)/themes/layout.tsx
@@ -4,7 +4,7 @@ import { getAllThemes } from "@themes/lib/theme";
 import { ThemeControls } from "@themes/components/theme-controls";
 import { NavigationActions } from "@/components/navigation";
 import { Button } from "@/components/button";
-import { SpeechBubbleIcon } from "@raycast/icons";
+import { SpeechBubbleIcon, BrandGithubIcon } from "@raycast/icons";
 import KeyboardShortcutsPanel from "@/app/(navigation)/(code)/components/KeyboardShortcutsPanel";
 import ExportButton from "@/app/(navigation)/(code)/components/ExportButton";
 import KeyboardShortcuts from "./components/keyboard-shortcuts";
@@ -29,6 +29,11 @@ export default async function Layout({ children, params }: { children: React.Rea
           <Button variant="transparent" asChild>
             <a href="mailto:feedback+rayso@raycast.com?subject=Themes">
               <SpeechBubbleIcon className="w-4 h-4" /> Send Feedback
+            </a>
+          </Button>
+          <Button variant="transparent" asChild>
+            <a href="https://github.com/raycast/ray-so" target="_blank">
+              <BrandGithubIcon className="w-4 h-4" /> Source Code
             </a>
           </Button>
           <KeyboardShortcuts />


### PR DESCRIPTION
- Added "Source Code" links to the navigation now that [ray.so is open source 🎉](https://twitter.com/rauchg/status/1808147941863088249)
- In the icon maker layout things were tight, let me know if the `2xl` breakpoint is acceptable

https://github.com/raycast/ray-so/assets/13041/8e569484-bc7d-4a9b-b704-f5fcba8ddd46
