### PR TITLE
Adjust Geist Mono fallback font stack to add full emoji support

### DIFF
--- a/app/(navigation)/(code)/components/Editor.module.css
+++ b/app/(navigation)/(code)/components/Editor.module.css
@@ -136,3 +136,8 @@
   font-family: var(--font-firacode), "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", monospace;
   font-weight: 400;
 }
+
+.geistMono {
+  font-family: var(--font-geist-mono), "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", monospace;
+  font-weight: 400;
+}

--- a/app/(navigation)/(code)/components/Editor.tsx
+++ b/app/(navigation)/(code)/components/Editor.tsx
@@ -20,7 +20,6 @@ import {
 } from "../store/themes";
 import useHotkeys from "../../../../utils/useHotkeys";
 import HighlightedCode from "./HighlightedCode";
-import { GeistMono } from "geist/font/mono";
 import classNames from "classnames";
 import { derivedFlashMessageAtom } from "../store/flash";
 import { highlightedLinesAtom, showLineNumbersAtom } from "../store";
@@ -237,7 +236,7 @@ function Editor() {
       className={classNames(
         styles.editor,
         themeFont === "geist-mono"
-          ? GeistMono.className
+          ? styles.geistMono
           : themeFont === "ibm-plex-mono"
           ? styles.ibmPlexMono
           : themeFont === "fira-code"

--- a/app/(navigation)/layout.tsx
+++ b/app/(navigation)/layout.tsx
@@ -1,6 +1,8 @@
 import { Fira_Code, IBM_Plex_Mono, JetBrains_Mono } from "next/font/google";
 import cn from "classnames";
 import { Navigation } from "@/components/navigation";
+import { GeistMono } from "geist/font/mono";
+import React from "react";
 
 const jetBrainsMono = JetBrains_Mono({
   subsets: ["latin"],
@@ -16,9 +18,23 @@ const ibmPlexMono = IBM_Plex_Mono({
 });
 const firaCode = Fira_Code({ subsets: ["latin"], weight: "400", display: "swap", variable: "--font-firacode" });
 
+/**
+ * We can't adjust the fallback stack of the font so instead we just extract the
+ * font name and create our own CSS variable using it so that we can configure the
+ * font stack to include emoji fonts.
+ */
+const geistMonoFontName = GeistMono.style.fontFamily.split(",")[0];
+
 export default function NavigationLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className={cn("h-full", jetBrainsMono.variable, ibmPlexMono.variable, firaCode.variable)}>
+    <div
+      className={cn("h-full", jetBrainsMono.variable, ibmPlexMono.variable, firaCode.variable)}
+      style={
+        {
+          "--font-geist-mono": geistMonoFontName,
+        } as React.CSSProperties
+      }
+    >
       <Navigation />
       <main className="flex flex-col min-h-full pt-[50px]">{children}</main>
     </div>


### PR DESCRIPTION
## Changes
- Adjust our geist mono font stack to include emoji fonts to fix an issue where certain emojis weren't rendering

## Screenshots
Before: 
![before](https://github.com/user-attachments/assets/aada03a4-167f-4588-adcf-bda603022d77)

After:
![after](https://github.com/user-attachments/assets/f6279bd4-e510-451f-a98d-6b56f40c8dce)
