### PR TITLE
#78 Fix plain text color bug

### DIFF
--- a/app/(navigation)/(code)/components/Editor.module.css
+++ b/app/(navigation)/(code)/components/Editor.module.css
@@ -122,6 +122,10 @@
   font-family: inherit;
 }
 
+.plainText {
+  color: var(--ray-foreground);
+}
+
 .jetBrainsMono {
   font-family: var(--font-jetbrainsmono), "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", monospace;
   font-weight: 500;

--- a/app/(navigation)/(code)/components/Editor.tsx
+++ b/app/(navigation)/(code)/components/Editor.tsx
@@ -23,6 +23,7 @@ import HighlightedCode from "./HighlightedCode";
 import classNames from "classnames";
 import { derivedFlashMessageAtom } from "../store/flash";
 import { highlightedLinesAtom, showLineNumbersAtom } from "../store";
+import { LANGUAGES } from "../util/languages";
 
 function indentText(text: string) {
   return text
@@ -243,7 +244,7 @@ function Editor() {
           ? styles.firaCode
           : styles.jetBrainsMono,
         isHighlightingLines && styles.isHighlightingLines,
-        showLineNumbers && styles.showLineNumbers
+        showLineNumbers && selectedLanguage !== LANGUAGES.plaintext && styles.showLineNumbers
       )}
       style={{ "--editor-padding": "16px 16px 21px 16px", ...themeCSS } as React.CSSProperties}
       data-value={code}

--- a/app/(navigation)/(code)/components/HighlightedCode.tsx
+++ b/app/(navigation)/(code)/components/HighlightedCode.tsx
@@ -62,7 +62,7 @@ const HighlightedCode: React.FC<PropTypes> = ({ selectedLanguage, code }) => {
 
   return (
     <div
-      className={classNames(styles.formatted)}
+      className={classNames(styles.formatted, selectedLanguage === LANGUAGES.plaintext && styles.plainText)}
       dangerouslySetInnerHTML={{
         __html: highlightedHtml,
       }}


### PR DESCRIPTION
Fixes missing `color` tokens for plain text. 
Line numbers don't work in this mode either so remove eventual padding.

![Sam 2024-08-05 at 1  05 16@2x](https://github.com/user-attachments/assets/185d9c4d-d205-486e-8c24-bc439f468921)
![Sam 2024-08-05 at 1  06 24@2x](https://github.com/user-attachments/assets/acd8ce08-17ba-4300-9218-637353ddfe86)
