### PR TITLE
Added support for dartlang syntax highlighting

### DIFF
--- a/app/(navigation)/(code)/util/languages.ts
+++ b/app/(navigation)/(code)/util/languages.ts
@@ -40,6 +40,11 @@ export const LANGUAGES: { [index: string]: Language } = {
     className: "css",
     src: () => import("shiki/langs/css.mjs"),
   },
+  dart: {
+    name: "Dart",
+    className: "diff",
+    src: () => import("shiki/langs/dart.mjs"),
+  },
   diff: {
     name: "Diff",
     className: "diff",

--- a/app/(navigation)/(code)/util/languages.ts
+++ b/app/(navigation)/(code)/util/languages.ts
@@ -42,7 +42,7 @@ export const LANGUAGES: { [index: string]: Language } = {
   },
   dart: {
     name: "Dart",
-    className: "dart",
+    className: "diff",
     src: () => import("shiki/langs/dart.mjs"),
   },
   diff: {

--- a/app/(navigation)/(code)/util/languages.ts
+++ b/app/(navigation)/(code)/util/languages.ts
@@ -42,7 +42,7 @@ export const LANGUAGES: { [index: string]: Language } = {
   },
   dart: {
     name: "Dart",
-    className: "diff",
+    className: "dart",
     src: () => import("shiki/langs/dart.mjs"),
   },
   diff: {


### PR DESCRIPTION
- Modified app/(navigation)/(code)/util/languages.ts and added dart in LANGUAGES object
```
dart: {
    name: "Dart",
    className: "diff",
    src: () => import("shiki/langs/dart.mjs"),
  },

```