### PR TITLE
fix: resolve issue with copying long text images to clipboard

### DIFF
--- a/app/(navigation)/(code)/components/ExportButton.tsx
+++ b/app/(navigation)/(code)/components/ExportButton.tsx
@@ -64,30 +64,25 @@ const ExportButton: React.FC = () => {
     setFlashShown(false);
   };
 
-  const copyPng = () => {
+  const copyPng = async () => {
     setFlashMessage({ icon: <ClipboardIcon />, message: "Copying PNG" });
+    if (!frameContext?.current) {
+      throw new Error("Couldn't find a frame to export");
+    }
+    const blob = await toBlob(frameContext.current, {
+      pixelRatio: exportSize,
+    });
+    if (!blob) {
+      throw new Error("expected toBlob to return a blob");
+    }
 
-    navigator.clipboard.write([
+    await navigator.clipboard.write([
       new ClipboardItem({
-        "image/png": new Promise((resolve) => {
-          if (!frameContext?.current) {
-            throw new Error("Couldn't find a frame to export");
-          }
-
-          toBlob(frameContext.current, {
-            pixelRatio: exportSize,
-          }).then((blob) => {
-            if (!blob) {
-              throw new Error("expected toBlob to return a blob");
-            }
-
-            resolve(blob);
-
-            setFlashMessage({ icon: <ClipboardIcon />, message: "PNG Copied to clipboard!", timeout: 2000 });
-          });
-        }),
+        "image/png": blob,
       }),
     ]);
+
+    setFlashMessage({ icon: <ClipboardIcon />, message: "PNG Copied to clipboard!", timeout: 2000 });
   };
 
   const saveSvg = async () => {


### PR DESCRIPTION
When I have a very long code snippet that needs to generate an image, I cannot directly copy the image to the clipboard, as shown in the video below

Before

https://github.com/user-attachments/assets/32ed9105-230f-431d-a467-89314e372048

After I fix 


https://github.com/user-attachments/assets/5d932683-9530-4f28-8604-6b684ab19421

