### PR TITLE
fix for Copy Image on Safari (#130)

### DIFF
--- a/app/(navigation)/(code)/components/ExportButton.tsx
+++ b/app/(navigation)/(code)/components/ExportButton.tsx
@@ -69,18 +69,21 @@ const ExportButton: React.FC = () => {
     if (!frameContext?.current) {
       throw new Error("Couldn't find a frame to export");
     }
-    const blob = await toBlob(frameContext.current, {
-      pixelRatio: exportSize,
-    });
-    if (!blob) {
-      throw new Error("expected toBlob to return a blob");
-    }
 
-    await navigator.clipboard.write([
-      new ClipboardItem({
-        "image/png": blob,
-      }),
-    ]);
+    const clipboardItem = new ClipboardItem(
+      {
+        "image/png": toBlob(frameContext.current, {
+          pixelRatio: exportSize,
+        }).then((blob) => {
+            if (!blob) {
+              throw new Error("expected toBlob to return a blob");
+            }
+            return blob;
+        }),
+      }
+    );
+
+    await navigator.clipboard.write([clipboardItem]);
 
     setFlashMessage({ icon: <ClipboardIcon />, message: "PNG Copied to clipboard!", timeout: 2000 });
   };


### PR DESCRIPTION
Apple's Clipboard API expects a Promise when writing to the clipboard, therefore I adapted the function to accommodate for this. 

I've tested on:

- Safari - Version 18.0 (20619.1.26.31.6)
- Edge - Version 128.0.2739.67 (Official build) (arm64)
- Chrome - Version 128.0.6613.121 (Official Build) (arm64)

This fixes #130 