### PR TITLE
Add a quinklink for Kagi Search

### DIFF
--- a/app/(navigation)/quicklinks/quicklinks.ts
+++ b/app/(navigation)/quicklinks/quicklinks.ts
@@ -405,6 +405,11 @@ const search: Quicklink[] = [
     name: "Search Perplexity",
     link: "https://perplexity.ai/search?q={query}",
   },
+  {
+    id: "kagi",
+    name: "Search Kagi",
+    link: "https://kagi.com/search?q={Query}",
+  },
 ];
 
 const shopping: Quicklink[] = [


### PR DESCRIPTION
Create a new entry in `quicklinks.ts` that adds a quicklink for the [Kagi](https://kagi.com) search engine.