### PR TITLE
Remove pointer events from partner theme backgrounds

### DIFF
--- a/app/(navigation)/(code)/components/Frame.module.css
+++ b/app/(navigation)/(code)/components/Frame.module.css
@@ -365,6 +365,7 @@
   width: 1293px;
   max-width: none;
   height: auto;
+  pointer-events: none;
   transform: translateX(calc(-50% - 200px));
 }
 
@@ -517,6 +518,7 @@
   width: calc(100% + 64px);
   height: 128px;
   mask-image: radial-gradient(farthest-side at 50% 100%, black, transparent);
+  pointer-events: none;
 }
 
 .clerkWindow {


### PR DESCRIPTION
Background images used in Clerk and Tailwind themes had pointer events, so you could right click and save/copy the image asset.