### PR TITLE
Add support for Move language

### DIFF
--- a/app/(navigation)/(code)/util/languages.ts
+++ b/app/(navigation)/(code)/util/languages.ts
@@ -150,6 +150,11 @@ export const LANGUAGES: { [index: string]: Language } = {
     className: "matlab",
     src: () => import("shiki/langs/matlab.mjs"),
   },
+  move: {
+    name: "Move",
+    className: "move",
+    src: () => import("shiki/langs/move.mjs"),
+  },
   plaintext: {
     name: "Plaintext",
     className: "",


### PR DESCRIPTION
Added support for Move, which is supported by Shiki already: https://shiki.style/languages

See screenshot for an example. 
<img width="762" alt="image" src="https://github.com/user-attachments/assets/4e3aa338-2ebd-4e84-b023-b451aa611040">
