### PR TITLE
Fix exported icon size in safari

### DIFF
--- a/app/(navigation)/icon/components/ExportModal.tsx
+++ b/app/(navigation)/icon/components/ExportModal.tsx
@@ -4,14 +4,14 @@ import React, { useState } from "react";
 import cn from "classnames";
 
 import { PlusIcon, TrashIcon } from "@raycast/icons";
-
-import { saveSvgAsPng } from "save-svg-as-png";
+import { toPng as htmlToPng } from "html-to-image";
 
 import styles from "./ExportModal.module.css";
 import { Select, SelectItem, SelectContent, SelectItemText, SelectValue, SelectTrigger } from "@/components/select";
 import { Button } from "@/components/button";
 import { Dialog, DialogContent, DialogTitle } from "@/components/dialog";
 import { Input, InputSlot } from "@/components/input";
+import download from "../../(code)/util/download";
 
 type ExportFormat = "PNG" | "SVG";
 
@@ -27,7 +27,10 @@ const exportToPng = async (svgRef: SvgRefType, fileName: string, size: number) =
   if (!svgRef.current) {
     return;
   }
-  return saveSvgAsPng(svgRef.current, `${fileName}.png`, { encoderOptions: 1, scale: size / 512 });
+
+  let dataUrl = await htmlToPng(svgRef.current, { pixelRatio: 1, quality: 1, width: size, height: size });
+  download(dataUrl, `${fileName}.png`);
+  return dataUrl;
 };
 
 const exportToSvg = async (svgRef: SvgRefType, fileName: string) => {

--- a/app/(navigation)/icon/icon-generator.tsx
+++ b/app/(navigation)/icon/icon-generator.tsx
@@ -5,7 +5,7 @@ import React, { use, useCallback, useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import cn from "classnames";
-import { svgAsPngUri } from "save-svg-as-png";
+import { toPng as htmlToPng } from "html-to-image";
 import { CSSTransition } from "react-transition-group";
 import { ColorChangeHandler, SketchPicker } from "react-color";
 import * as Popover from "@radix-ui/react-popover";
@@ -29,8 +29,6 @@ import {
   CopyClipboardIcon,
   LinkIcon,
   BrushIcon,
-  SpeechBubbleIcon,
-  BrandGithubIcon,
   MagnifyingGlassIcon,
 } from "@raycast/icons";
 
@@ -343,7 +341,7 @@ export const IconGenerator = () => {
         return settingsToSet;
       });
     },
-    [setSettings]
+    [setSettings],
   );
 
   const showInfoMessage = (message: string, showUndo = false) => {
@@ -398,7 +396,7 @@ export const IconGenerator = () => {
       // Fixes @2x png export instead of the same size as png
       const realPixelRatio = window.devicePixelRatio;
       window.devicePixelRatio = 1;
-      const dataUri = await svgAsPngUri(svgRef.current, { encoderOptions: 1 });
+      const dataUri = await htmlToPng(svgRef.current, { pixelRatio: 1, width: 512, height: 512 });
       const blob = await (await fetch(dataUri)).blob();
       await navigator.clipboard.write([
         new ClipboardItem({
@@ -413,13 +411,13 @@ export const IconGenerator = () => {
   const onCopyShareUrl = async () => {
     showInfoMessage("Copying URL to clipboard…", false);
     const url = `${BASE_URL}/icon?${new URLSearchParams(
-      Object.entries(settings).map(([key, value]) => [key, String(value)])
+      Object.entries(settings).map(([key, value]) => [key, String(value)]),
     ).toString()}`;
 
     let urlToCopy = url;
     const encodedUrl = encodeURIComponent(url);
     const response = await fetch(`https://ray.so/api/shorten-url?url=${encodedUrl}&ref=icons`).then((res) =>
-      res.json()
+      res.json(),
     );
 
     if (response.link) {
@@ -720,7 +718,7 @@ export const IconGenerator = () => {
   }
 
   const filteredIcons = Object.keys(Icons).filter((key) =>
-    key.toLowerCase().includes(searchTerm.toLowerCase())
+    key.toLowerCase().includes(searchTerm.toLowerCase()),
   ) as IconName[];
 
   const scaleOptions = scales.map((value) => ({
@@ -890,7 +888,7 @@ export const IconGenerator = () => {
               styles.panel,
               styles.icons,
               iconsPanelOpened && styles.opened,
-              optionsPanelOpened && styles.hidden
+              optionsPanelOpened && styles.hidden,
             )}
           >
             <button
@@ -1014,7 +1012,7 @@ export const IconGenerator = () => {
               styles.options,
               panelsVisible ? "" : styles.hidden,
               iconsPanelOpened && styles.hidden,
-              optionsPanelOpened && styles.opened
+              optionsPanelOpened && styles.opened,
             )}
           >
             <button

--- a/app/(navigation)/icon/save-svg-as-png.d.ts
+++ b/app/(navigation)/icon/save-svg-as-png.d.ts
@@ -1,5 +1,0 @@
-declare module "save-svg-as-png" {
-  // TODO: real options type?
-  export function saveSvgAsPng(el: SVGSVGElement, filename?: string, options: Record<string, string | number>): void;
-  export function svgAsPngUri(el: SVGSVGElement, options: Record<string, string | number>): Awaited<string>;
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,6 @@
         "react-color": "^2.19.3",
         "react-dom": "18.3.1",
         "react-transition-group": "^4.4.5",
-        "save-svg-as-png": "^1.4.17",
         "shiki": "^1.0.0",
         "sonner": "^1.5.0",
         "tailwind-merge": "^2.3.0",
@@ -12823,12 +12822,6 @@
       "version": "10.3.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.3.0.tgz",
       "integrity": "sha512-QpLs9D9v9kArv4lfDEgg1X/gN5XLnf/A6l9cs8SPZLRZR3ZkY9+kwIQTxm+fsSej5UMYGE8fdoaZVIBlqG0XTw==",
-      "license": "MIT"
-    },
-    "node_modules/save-svg-as-png": {
-      "version": "1.4.17",
-      "resolved": "https://registry.npmjs.org/save-svg-as-png/-/save-svg-as-png-1.4.17.tgz",
-      "integrity": "sha512-7QDaqJsVhdFPwviCxkgHiGm9omeaMBe1VKbHySWU6oFB2LtnGCcYS13eVoslUgq6VZC6Tjq/HddBd1K6p2PGpA==",
       "license": "MIT"
     },
     "node_modules/scheduler": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "react-color": "^2.19.3",
     "react-dom": "18.3.1",
     "react-transition-group": "^4.4.5",
-    "save-svg-as-png": "^1.4.17",
     "shiki": "^1.0.0",
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.3.0",


### PR DESCRIPTION
Replaces outdated svg-to-png library with the same one we use for code images exports. This fixes an issue where icons in Icon Maker were always 16x16px regardless of size in Safari