### PR TITLE
Add Kotlin Documentation quicklink

### DIFF
--- a/app/(navigation)/quicklinks/quicklinks.ts
+++ b/app/(navigation)/quicklinks/quicklinks.ts
@@ -266,6 +266,11 @@ const development: Quicklink[] = [
       link: "https://github.com/alanwill",
     },
   },
+  {
+    id: "kotlin-docs",
+    link: "https://kotlinlang.org/docs/home.html?q={argument}&s=full",
+    name: "Kotlin Docs",
+  },
 ];
 
 const design: Quicklink[] = [


### PR DESCRIPTION
Hi folks 👋

I'd like to add a quicklink to provide a fast access to the Kotlin Documentation: https://kotlinlang.org/docs/home.html