### PR TITLE
Add "format code" support for Python

### DIFF
--- a/app/(navigation)/(code)/util/formatCode.ts
+++ b/app/(navigation)/(code)/util/formatCode.ts
@@ -14,20 +14,6 @@ const parsers = {
 
 export const formatterSupportedLanguages: Language["name"][] = Object.keys(parsers);
 
-const ruffConfig = {
-  preview: false,
-  builtins: [],
-  "target-version": "py312",
-  "line-length": 80,
-  "indent-width": 4,
-  format: {
-    "indent-style": "space",
-    "quote-style": "double",
-    "skip-magic-trailing-comma": false,
-    "line-ending": "auto",
-  },
-};
-
 const prettierConfig = {
   singleQuote: false,
   printWidth: 80,
@@ -42,7 +28,7 @@ const formatCode = async (code: string, language: Language | null) => {
     const { default: initRuff, Workspace } = await import("@astral-sh/ruff-wasm-web");
     await initRuff();
 
-    const workspace = new Workspace(ruffConfig);
+    const workspace = new Workspace(Workspace.defaultSettings());
     const formatted = workspace.format(code);
     return formatted.replace(/\n$/, "");
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "ray.so",
       "version": "0.1.0",
       "dependencies": {
-        "@astral-sh/ruff-wasm-web": "^0.9.6",
+        "@astral-sh/ruff-wasm-web": "0.9.9",
         "@next/bundle-analyzer": "^14.2.4",
         "@radix-ui/react-collapsible": "^1.0.3",
         "@radix-ui/react-context-menu": "^2.1.5",
@@ -108,9 +108,9 @@
       }
     },
     "node_modules/@astral-sh/ruff-wasm-web": {
-      "version": "0.9.6",
-      "resolved": "https://registry.npmjs.org/@astral-sh/ruff-wasm-web/-/ruff-wasm-web-0.9.6.tgz",
-      "integrity": "sha512-rR28EcWvx92mplU6pid11sbKiaCWN+5cNPTPN6OgP0MfOF/ScJQBAaul7SMqt2rgok6QYrz50+OXBRg1DQ0W1A==",
+      "version": "0.9.9",
+      "resolved": "https://registry.npmjs.org/@astral-sh/ruff-wasm-web/-/ruff-wasm-web-0.9.9.tgz",
+      "integrity": "sha512-VGjO627xKzszpNRVbrCQyYXIXfh8t9Ju6t+GDPjoRUF+1D6Dlgze0Qjl1fKWLTecNUrd55oKgFutezSuwGfMdA==",
       "license": "MIT"
     },
     "node_modules/@babel/code-frame": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ray.so",
       "version": "0.1.0",
       "dependencies": {
+        "@astral-sh/ruff-wasm-web": "^0.9.6",
         "@next/bundle-analyzer": "^14.2.4",
         "@radix-ui/react-collapsible": "^1.0.3",
         "@radix-ui/react-context-menu": "^2.1.5",
@@ -105,6 +106,12 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@astral-sh/ruff-wasm-web": {
+      "version": "0.9.6",
+      "resolved": "https://registry.npmjs.org/@astral-sh/ruff-wasm-web/-/ruff-wasm-web-0.9.6.tgz",
+      "integrity": "sha512-rR28EcWvx92mplU6pid11sbKiaCWN+5cNPTPN6OgP0MfOF/ScJQBAaul7SMqt2rgok6QYrz50+OXBRg1DQ0W1A==",
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.24.6",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "node": "^18"
   },
   "dependencies": {
+    "@astral-sh/ruff-wasm-web": "^0.9.6",
     "@next/bundle-analyzer": "^14.2.4",
     "@radix-ui/react-collapsible": "^1.0.3",
     "@radix-ui/react-context-menu": "^2.1.5",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "node": "^18"
   },
   "dependencies": {
-    "@astral-sh/ruff-wasm-web": "^0.9.6",
+    "@astral-sh/ruff-wasm-web": "0.9.9",
     "@next/bundle-analyzer": "^14.2.4",
     "@radix-ui/react-collapsible": "^1.0.3",
     "@radix-ui/react-context-menu": "^2.1.5",


### PR DESCRIPTION
Adding support for formatting Python code using Ruff.

Ruff is a rust based fast python formatter. They also have a wasm build of the same. Built by the Astral team (Charlie Marsh)
ruff repo: https://github.com/astral-sh/ruff

Note:
- Currently there are console logs from somewhere deep inside ruff wasm. I already asked on Astral discord on how to turn off that log - https://discord.com/channels/1039017663004942429/1340080349534748702