### PR TITLE
Add music prompts (cross copy current track url)

### DIFF
--- a/app/(navigation)/prompts/prompts.ts
+++ b/app/(navigation)/prompts/prompts.ts
@@ -507,6 +507,15 @@ const music: Prompt[] = [
     model: "raycast-ray1",
     date: "2025-02-26",
   },
+  {
+    id: "copy-currently-playing-apple-to-spotify",
+    title: "Copy Spotify URL from Currently Playing Apple Music Track",
+    prompt: "@music{id=2bfe94cd-50ab-4e48-a6cd-f1ff47a72706} Take the currently playing track, @spotify-player{id=320f40ef-a633-415a-ab0e-1e99515478f7} search that track and @clipboard{id=builtin_package_clipboardHistory} copy the link of the spotify song. Not in markdown, just the link.",
+    icon: "music",
+    creativity: "none",
+    model: "raycast-ray1-mini",
+    date: "2025-03-16",
+  },
 ];
 
 const ideas: Prompt[] = [

--- a/app/(navigation)/prompts/prompts.ts
+++ b/app/(navigation)/prompts/prompts.ts
@@ -515,6 +515,10 @@ const music: Prompt[] = [
     creativity: "none",
     model: "raycast-ray1-mini",
     date: "2025-03-16",
+    author: {
+      name: "Kian Pasani",
+      link: "https://github.com/kianhub",
+    },
   },
   {
     id: "copy-currently-playing-spotify-to-apple",
@@ -524,6 +528,10 @@ const music: Prompt[] = [
     creativity: "none",
     model: "raycast-ray1-mini",
     date: "2025-03-16",
+    author: {
+      name: "Kian Pasani",
+      link: "https://github.com/kianhub",
+    },
   }
 ];
 

--- a/app/(navigation)/prompts/prompts.ts
+++ b/app/(navigation)/prompts/prompts.ts
@@ -516,6 +516,15 @@ const music: Prompt[] = [
     model: "raycast-ray1-mini",
     date: "2025-03-16",
   },
+  {
+    id: "copy-currently-playing-spotify-to-apple",
+    title: "Copy Apple Music URL from Currently Playing Spotify Track",
+    prompt: "@spotify-player{id=320f40ef-a633-415a-ab0e-1e99515478f7} Take the currently playing track, @music{id=2bfe94cd-50ab-4e48-a6cd-f1ff47a72706} search that track and @clipboard{id=builtin_package_clipboardHistory} copy the link of the spotify song. Not in markdown, just the link.",
+    icon: "music",
+    creativity: "none",
+    model: "raycast-ray1-mini",
+    date: "2025-03-16",
+  }
 ];
 
 const ideas: Prompt[] = [


### PR DESCRIPTION
This pull request adds new prompt configurations to the `music` array in the `prompts.ts` file. These prompts are designed to facilitate copying the currently playing track's URL between Apple Music and Spotify.

New prompt configurations:

* Added a prompt to copy the Spotify URL from the currently playing Apple Music track. (`app/(navigation)/prompts/prompts.ts`)
* Added a prompt to copy the Apple Music URL from the currently playing Spotify track. (`app/(navigation)/prompts/prompts.ts`)