### PR TITLE
Fix: await getRaycastFlavor promise before snippet import navigation

### DIFF
--- a/app/(navigation)/snippets/[[...slug]]/snippets.tsx
+++ b/app/(navigation)/snippets/[[...slug]]/snippets.tsx
@@ -191,12 +191,10 @@ export default function Snippets() {
     setToastMessage("Copied URL to clipboard!");
   }, [makeQueryString]);
 
-  const raycastProtocol = getRaycastFlavor();
-
-  const handleAddToRaycast = React.useCallback(
-    () => router.replace(`${raycastProtocol}://snippets/import?${makeQueryString()}`),
-    [router, makeQueryString, raycastProtocol],
-  );
+  const handleAddToRaycast = React.useCallback(async () => {
+    const raycastProtocol = await getRaycastFlavor();
+    router.replace(`${raycastProtocol}://snippets/import?${makeQueryString()}`);
+  }, [router, makeQueryString]);
 
   React.useEffect(() => {
     setIsTouch(isTouchDevice());


### PR DESCRIPTION
Hello @KELiON ,

I've created a fix for the Raycast snippet import functionality that was failing. The issue was that we weren't properly awaiting the `getRaycastFlavor()` Promise before attempting to navigate to the Raycast URL.

**Before:**

https://github.com/user-attachments/assets/e7ad02a1-29ca-45d9-8e22-59191cc0da43 

**After:**

https://github.com/user-attachments/assets/96051f31-1b68-4b62-b99f-259a02599965



## Changes:
- Ensured proper async/await in `handleAddToRaycast()`

The fix is minimal and focused only on the async behavior. Please let me know if you need any clarification or have suggestions for improvement.

Thanks for your time!