### PR TITLE
Add Qwant quicklink to the search category

### DIFF
--- a/app/(navigation)/quicklinks/quicklinks.ts
+++ b/app/(navigation)/quicklinks/quicklinks.ts
@@ -524,6 +524,11 @@ const search: Quicklink[] = [
       link: "https://www.raycast.com/ViGeng/via=ViGeng",
     },
   },
+  {
+    id: "qwant",
+    name: "Search Qwant",
+    link: "https://qwant.com/?q={Query}",
+  },
 ];
 
 const shopping: Quicklink[] = [


### PR DESCRIPTION
This pull request adds a quicklink for Qwant in the search category

Qwant is a privacy-focused, EU-based search engine

