### PR TITLE
Fix crash when sharing quicklinks

### DIFF
--- a/app/(navigation)/quicklinks/components/quicklink.tsx
+++ b/app/(navigation)/quicklinks/components/quicklink.tsx
@@ -21,6 +21,7 @@ import { makeUrl, addQuicklinkToRaycast } from "../utils/actions";
 
 import { shortenUrl } from "@/utils/common";
 import { useRouter } from "next/navigation";
+import { isValidLink } from "../utils/isValidLink";
 
 type QuicklinkComponentProps = {
   quicklink: Quicklink;
@@ -33,8 +34,9 @@ export function QuicklinkComponent({ quicklink, isSelected, setIsSelected, updat
   const router = useRouter();
 
   let domain = "";
-  if (quicklink?.icon?.link || quicklink.link.startsWith("https")) {
-    const url = new URL(quicklink?.icon?.link || quicklink.link);
+  const iconLink = quicklink?.icon?.link || quicklink.link;
+  if (isValidLink(iconLink)) {
+    const url = new URL(iconLink);
     domain = url.hostname.replace("www.", "");
   }
 
@@ -100,8 +102,7 @@ export function QuicklinkComponent({ quicklink, isSelected, setIsSelected, updat
           <div className="w-full flex flex-col space-between h-full">
             <div className="flex-1">
               <div className="flex w-8 h-8 flex-shrink-0 items-center justify-center border border-dashed border-white/20 rounded bg-gradient-radial from-[#171717] to-black text-gray-12 transition-colors duration-150 mb-2 group-hover:text-gray-12">
-                {quicklink?.icon?.name ||
-                (!quicklink.link.startsWith("http") && !quicklink?.icon?.link?.startsWith("http")) ? (
+                {!isValidLink(iconLink) ? (
                   <IconComponent icon={quicklink?.icon?.name || "link"} />
                 ) : (
                   <img

--- a/app/(navigation)/quicklinks/shared/page.tsx
+++ b/app/(navigation)/quicklinks/shared/page.tsx
@@ -4,7 +4,7 @@ import { Metadata } from "next";
 import { Shared } from "./shared";
 import { Quicklink } from "../quicklinks";
 import { nanoid } from "nanoid";
-import { Base64 } from "js-base64";
+import { isValidLink } from "../utils/isValidLink";
 
 type Props = {
   params: Promise<{ slug: string }>;
@@ -46,8 +46,9 @@ export async function generateMetadata(props: Props): Promise<Metadata> {
     const pageTitle = `${quicklink.name} - Raycast Quicklink`;
     const pageDescription = "Raycast Quicklink";
     let iconUrl = "";
-    if (quicklink?.icon?.link || quicklink.link.startsWith("https")) {
-      const url = new URL(quicklink?.icon?.link || quicklink.link);
+    const iconLink = quicklink?.icon?.link || quicklink.link;
+    if (isValidLink(iconLink)) {
+      const url = new URL(iconLink);
       const domain = url.hostname.replace("www.", "");
       iconUrl = `https://www.google.com/s2/favicons?sz=64&domain=${domain}`;
     }

--- a/app/(navigation)/quicklinks/shared/shared.tsx
+++ b/app/(navigation)/quicklinks/shared/shared.tsx
@@ -40,7 +40,15 @@ export function Shared({ quicklinks }: { quicklinks: Quicklink[] }) {
     [quicklinks],
   );
 
-  const raycastProtocol = getRaycastFlavor();
+  const [raycastProtocol, setRaycastProtocol] = React.useState("");
+
+  React.useEffect(() => {
+    async function fetchRaycastProtocol() {
+      const protocol = await getRaycastFlavor();
+      setRaycastProtocol(protocol);
+    }
+    fetchRaycastProtocol();
+  }, []);
 
   const [categories, setCategories] = React.useState(initialCategories);
   useEffect(() => {

--- a/app/(navigation)/quicklinks/utils/isValidLink.ts
+++ b/app/(navigation)/quicklinks/utils/isValidLink.ts
@@ -1,0 +1,9 @@
+export function isValidLink(link: string) {
+  try {
+    const url = new URL(link);
+    // quicklinks with dynamic arguments part of the hostname are not valid links
+    return url.hostname.includes("{") ? false : true;
+  } catch (error) {
+    return false;
+  }
+}


### PR DESCRIPTION
Fixes an issue when sharing quicklinks with dynamic arguments as part of the host would crash e.g.
` https://{argument name="website" options="raycast, google" default="raycast"}.com`