### PR TITLE
Add language support for console(shell session)

### DIFF
--- a/app/(navigation)/(code)/util/languages.ts
+++ b/app/(navigation)/(code)/util/languages.ts
@@ -24,6 +24,10 @@ export const LANGUAGES: { [index: string]: Language } = {
     name: "Clojure",
     src: () => import("shiki/langs/clojure.mjs"),
   },
+  console: {
+    name: "Console",
+    src: () => import("shiki/langs/console.mjs"),
+  },
   crystal: {
     name: "Crystal",
     src: () => import("shiki/langs/crystal.mjs"),


### PR DESCRIPTION
It's a good point that sharing terminal output as screenshots can be inconvenient. Having a direct way to view it on ray.so would be really helpful.

That's why I've added the `console` language, which is also known as `shellsession` or `shell-session` in other contexts.

![Example for console language](https://github.com/user-attachments/assets/0da0c539-7935-448a-aa7c-6dde69a2e2c9)
