### PR TITLE
Allow single line code blocks

### DIFF
--- a/app/(navigation)/(code)/components/Editor.module.css
+++ b/app/(navigation)/(code)/components/Editor.module.css
@@ -1,7 +1,8 @@
 .editor {
   display: grid;
   width: 100%;
-  grid-template: 1fr / 1fr;
+  min-height: 0;
+  grid-template: auto / 1fr;
 
   &:after {
     content: attr(data-value) " ";
@@ -62,7 +63,6 @@
 .textarea,
 .formatted,
 .editor:after {
-  /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
   padding: var(--editor-padding);
   margin: 0;
   counter-increment: step 0;
@@ -105,9 +105,9 @@
 .textarea {
   z-index: 2;
   overflow: hidden;
+  min-height: min-content;
   border: none;
   background: transparent;
-  /* stylelint-disable-next-line csstools/value-no-unknown-custom-properties */
   caret-color: var(--ray-foreground);
   resize: none;
   -webkit-text-fill-color: transparent;

--- a/app/(navigation)/(code)/components/Editor.tsx
+++ b/app/(navigation)/(code)/components/Editor.tsx
@@ -258,10 +258,11 @@ function Editor() {
             numberOfLines > 8 && styles.showLineNumbersLarge,
           ],
       )}
-      style={{ "--editor-padding": "16px 16px 21px 16px", ...themeCSS } as React.CSSProperties}
+      style={{ "--editor-padding": "16px", ...themeCSS } as React.CSSProperties}
       data-value={code}
     >
       <textarea
+        rows={1}
         tabIndex={-1}
         autoComplete="off"
         autoCorrect="off"

--- a/app/(navigation)/(code)/components/Frame.module.css
+++ b/app/(navigation)/(code)/components/Frame.module.css
@@ -37,7 +37,7 @@
 
 .window {
   display: flex;
-  min-height: 120px;
+  min-height: 100px;
   flex-direction: column;
   align-items: stretch;
   padding-top: 10px;


### PR DESCRIPTION
Previously if you put a single line of code you'd get extra padding below due to the textarea defaulting to two rows. This PR improves this by setting the initial rows to 1 and making the frame only use as much space as needed by the code.

before: 
![ray-so-export (16)](https://github.com/user-attachments/assets/37a9fd16-be21-4771-8d1f-f3a8e7c875a8)

after:
![ray-so-export (17)](https://github.com/user-attachments/assets/e176cd02-da4b-40e3-9a7b-f3314ecdd9f6)
