### PR TITLE
Runtime: Update to Node.js v22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
       "devDependencies": {
         "@svgr/webpack": "^6.4.0",
         "@types/lodash.debounce": "^4.0.9",
-        "@types/node": "^20",
+        "@types/node": "^22",
         "@types/react": "19.0.10",
         "@types/react-color": "^3.0.12",
         "@types/react-dom": "19.0.4",
@@ -78,7 +78,7 @@
         "typescript": "^5.4.2"
       },
       "engines": {
-        "node": "^18"
+        "node": "^22"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -4335,12 +4335,12 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.14.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.14.1.tgz",
-      "integrity": "sha512-T2MzSGEu+ysB/FkWfqmhV3PLyQlowdptmmgD20C6QxsS8Fmv5SjpZ1ayXaEC0S21/h5UJ9iA6W/5vSNU5l00OA==",
+      "version": "22.16.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.16.4.tgz",
+      "integrity": "sha512-PYRhNtZdm2wH/NT2k/oAJ6/f2VD2N2Dag0lGlx2vWgMSJXGNmlce5MiTQzoWAiIJtso30mjnfQCOKVH+kAQC/g==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -12911,9 +12911,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "type-check": "tsc --noEmit"
   },
   "engines": {
-    "node": "^18"
+    "node": "^22"
   },
   "dependencies": {
     "@astral-sh/ruff-wasm-web": "0.9.9",
@@ -64,7 +64,7 @@
   "devDependencies": {
     "@svgr/webpack": "^6.4.0",
     "@types/lodash.debounce": "^4.0.9",
-    "@types/node": "^20",
+    "@types/node": "^22",
     "@types/react": "19.0.10",
     "@types/react-color": "^3.0.12",
     "@types/react-dom": "19.0.4",


### PR DESCRIPTION
Necessary because of https://vercel.com/changelog/node-js-18-is-being-deprecated.