### PR TITLE
Fix dia browser icon offset

### DIFF
--- a/app/(navigation)/icon/components/ResultIcon.tsx
+++ b/app/(navigation)/icon/components/ResultIcon.tsx
@@ -113,18 +113,20 @@ const ResultIcon = React.forwardRef<SVGSVGElement, PropTypes>(
         </defs>
 
         {IconComponent ? (
-          <IconComponent
-            width={settings.iconSize}
-            height={settings.iconSize}
-            x={(size - settings.iconSize) / 2 + +settings.iconOffsetX}
-            y={(size - settings.iconSize) / 2 + +settings.iconOffsetY}
-            style={{ color: settings.iconColor }}
-            alignmentBaseline="middle"
-          />
+          <g
+            transform={`translate(${(size - settings.iconSize) / 2 + +settings.iconOffsetX}, ${(size - settings.iconSize) / 2 + +settings.iconOffsetY})`}
+          >
+            <IconComponent
+              width={settings.iconSize}
+              height={settings.iconSize}
+              style={{ color: settings.iconColor }}
+              alignmentBaseline="middle"
+            />
+          </g>
         ) : null}
       </svg>
     );
-  }
+  },
 );
 
 ResultIcon.displayName = "ResultIcon";


### PR DESCRIPTION
Fix SVG icon offset in Dia browser by using `transform="translate()"` instead of `x` and `y` attributes.

The `x` and `y` attributes are not universally supported on all SVG elements, causing the icon to be offset in stricter browsers like Dia. Wrapping the icon in a `<g>` element and applying `transform="translate()"` provides a universally supported and standard SVG positioning method.

---
<a href="https://cursor.com/background-agent?bcId=bc-e2bf77ef-3568-4088-a67e-5e54c8b4965d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e2bf77ef-3568-4088-a67e-5e54c8b4965d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

