### PR TITLE
Add Liquid syntax highlighting support

### DIFF
--- a/app/(navigation)/(code)/util/languages.ts
+++ b/app/(navigation)/(code)/util/languages.ts
@@ -120,6 +120,10 @@ export const LANGUAGES: { [index: string]: Language } = {
     name: "LaTeX",
     src: () => import("shiki/langs/latex.mjs"),
   },
+  liquid: {
+    name: "Liquid",
+    src: () => import("shiki/langs/liquid.mjs"),
+  },
   lisp: {
     name: "Lisp",
     src: () => import("shiki/langs/lisp.mjs"),


### PR DESCRIPTION
### Add Liquid (Shopify) templating language to the list of supported languages for syntax highlighting.

**Note:** Auto-detection will not recognize Liquid code because `highlight.js` does not include Liquid in its core bundle. Users will need to manually select “Liquid” from the language dropdown. Auto-detection would require adding the `highlightjs-liquid` package and configuring highlight.js to include it in the detection set.