### PR TITLE
Add GitHub Pull Requests Quicklinks

### DIFF
--- a/app/(navigation)/quicklinks/quicklinks.ts
+++ b/app/(navigation)/quicklinks/quicklinks.ts
@@ -145,6 +145,26 @@ const development: Quicklink[] = [
     },
   },
   {
+    id: "githubPullRequests",
+    name: "GitHub Pull Requests (Created)",
+    link: "https://github.com/pulls",
+    description: "View your created GitHub Pull Requests",
+    author: {
+      name: "a2c",
+      link: "https://github.com/atzzCokeK",
+    },
+  },
+  {
+    id: "githubReviewRequestedPullRequests",
+    name: "GitHub Pull Requests (Review Requested)",
+    link: "https://github.com/pulls/review-requested",
+    description: "View GitHub Pull Requests where your review is requested",
+    author: {
+      name: "a2c",
+      link: "https://github.com/atzzCokeK",
+    },
+  },
+  {
     id: "huggingface",
     name: "Search Hugging Face",
     description: "Search for models, datasets, and more",


### PR DESCRIPTION
## Proposal

Add two new GitHub quicklinks to the Development category that provide direct access to Pull Request management pages:

1. **GitHub Pull Requests (Created)** - Quick access to your created PRs
2. **GitHub Pull Requests (Review Requested)** - Quick access to PRs where your review is requested

## Motivation

These quicklinks streamline a core part of the developer workflow:
- Developers check PRs multiple times daily
- Direct Raycast access eliminates multiple clicks through GitHub's UI
- The "review requested" view is particularly buried and easy to miss
- Makes PR management one keystroke away

## Implementation

Both quicklinks follow the existing pattern used by other GitHub quicklinks in the Development category (e.g., `github`, `githubcopilot`). Icons are automatically fetched from GitHub's favicon.

## References

Similar quicklink additions: #357, #214