### PR TITLE
proposal: Use hyphen in default icon filename for Raycast Extensions

### DIFF
--- a/app/(navigation)/icon/icon-generator.tsx
+++ b/app/(navigation)/icon/icon-generator.tsx
@@ -299,7 +299,7 @@ export const IconGenerator = () => {
 
   const [draggingFile, setDraggingFile] = useState<boolean>(false);
   const [settings, setSettings] = useState<SettingsType>({
-    fileName: "extension_icon",
+    fileName: "extension-icon",
     icon: "raycast-logo-pos",
     backgroundRadius: 128,
     backgroundStrokeSize: 0,


### PR DESCRIPTION
## Proposal

Update the default icon filename in Icon Maker from `extension_icon` to `extension-icon` to match Raycast Extension development conventions.

## Problem

Currently, Icon Maker generates icons with the default filename `extension_icon` (underscore). However, Raycast Extensions expect the icon file to be named `extension-icon` (hyphen) by default. This mismatch creates unnecessary friction:

- Users must manually rename the exported icon file
- It's easy to miss this step, leading to broken icons in extensions
- The inconsistency goes against the tool's goal of streamlining the extension development workflow

## Changes

- Updated the default `fileName` in the initial settings state from `"extension_icon"` to `"extension-icon"`

## Impact

- Users generating icons for Raycast Extensions will now get the correct default filename
- Reduces friction in the extension development workflow by eliminating the need to manually rename exported icons
- No breaking changes - this only affects the default value

## To Wonderful Reviewers

This PR is a proposal based on my experience developing Raycast extensions. If there are reasons to keep the current name, please feel free to close this PR. Thank you for all your efforts!
