### PR TITLE
fix: adjust autowidth for Firecrawl theme to match other themes

### DIFF
--- a/app/(navigation)/(code)/components/frames/FirecrawlFrame.module.css
+++ b/app/(navigation)/(code)/components/frames/FirecrawlFrame.module.css
@@ -16,7 +16,6 @@
   position: relative;
   overflow: visible;
   padding-bottom: 0px;
-  container-type: inline-size;
 }
 
 /* Negative inset extends overlay to frame edges (black box); canvas draws lines to its edges. */
@@ -41,11 +40,16 @@
   stroke: currentColor;
 }
 
-.asciiArt {
+.asciiArtContainer {
   position: absolute;
   right: 0;
   bottom: 0;
   left: 0;
+  container-type: inline-size;
+  pointer-events: none;
+}
+
+.asciiArt {
   margin: 0;
   color: #f97316;
   font-family: monospace;
@@ -58,7 +62,6 @@
     rgba(0, 0, 0, 0.9) 100%
   );
   mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0.1) 0%, rgba(0, 0, 0, 0.5) 50%, rgba(0, 0, 0, 0.9) 100%);
-  pointer-events: none;
   text-align: center;
   white-space: pre;
 }

--- a/app/(navigation)/(code)/components/frames/FirecrawlFrame.tsx
+++ b/app/(navigation)/(code)/components/frames/FirecrawlFrame.tsx
@@ -135,7 +135,11 @@ const FirecrawlFrame = () => {
     >
       {!showBackground && <div data-ignore-in-export className={sharedStyles.transparentPattern}></div>}
       <div className={styles.window}>
-        {showBackground && <pre className={styles.asciiArt}>{FIRECRAWL_ASCII_ART}</pre>}
+        {showBackground && (
+          <div className={styles.asciiArtContainer}>
+            <pre className={styles.asciiArt}>{FIRECRAWL_ASCII_ART}</pre>
+          </div>
+        )}
         <Editor />
         {showBackground && (
           <FirecrawlFrameCanvas gridColor={gridColor} padding={padding} exportPixelRatio={exportSize} />


### PR DESCRIPTION
### Description
This PR fixes a layout issue where the **Firecrawl** theme rendered with an incorrect, narrower width compared to other themes. 

The issue was caused by the `container-type: inline-size` property being applied directly to the main frame container. This interfered with the automatic width calculation of the code editor.

### Changes
- **CSS Refactor**: Removed `container-type: inline-size` from the main frame in `FirecrawlFrame.module.css`.
- **New Wrapper**: Created `.asciiArtContainer` with `container-type: inline-size` and `pointer-events: none` to isolate the background ASCII art logic.
- **Component Update**: In `FirecrawlFrame.tsx`, wrapped the ASCII art `<pre>` tag with the new container to ensure the layout remains consistent without affecting the parent's dimensions.

### Screenshots
| Before (Buggy Width) | After (Fixed Auto-width) |
| :--- | :--- |
| ![Before](https://snipboard.io/rWXLTt.jpg) | ![After](https://snipboard.io/whm05A.jpg) |