### PR TITLE
OpenAI theme background toggle

### DIFF
--- a/app/(navigation)/(code)/components/frames/OpenAIFrame.module.css
+++ b/app/(navigation)/(code)/components/frames/OpenAIFrame.module.css
@@ -52,3 +52,7 @@
       0px 2.02px 2.297px 0px rgba(0, 0, 0, 0.01);
   }
 }
+
+.frame.noBackground {
+  background: transparent;
+}


### PR DESCRIPTION
Add missing `noBackground` CSS class to enable background toggling for the OpenAI theme.

The `OpenAIFrame.tsx` component was applying a `styles.noBackground` class when the background toggle was off, but this class was not defined in `OpenAIFrame.module.css`. This prevented the background from becoming transparent, making the toggle ineffective. Adding the class ensures the background can be properly toggled off.

---
<p><a href="https://cursor.com/agents/bc-8f8e7920-54be-4e78-855d-754da39d40f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8f8e7920-54be-4e78-855d-754da39d40f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

