### PR TITLE
Add Tokyo Night Storm theme

### DIFF
--- a/app/(navigation)/themes/themes/lockeag/Tokyo Night Storm.json
+++ b/app/(navigation)/themes/themes/lockeag/Tokyo Night Storm.json
@@ -1,0 +1,21 @@
+{
+  "appearance": "dark",
+  "name": "Tokyo Night Storm",
+  "version": "1",
+  "author": "Locke",
+  "authorUsername": "lockeag",
+  "colors": {
+    "background": "#24283B",
+    "backgroundSecondary": "#1D202F",
+    "text": "#C0CAF5",
+    "selection": "#7AA2F7",
+    "loader": "#FF9E64",
+    "red": "#F7768E",
+    "orange": "#FF9E64",
+    "yellow": "#E0AF68",
+    "green": "#9ECE6A",
+    "blue": "#7AA2F7",
+    "purple": "#7DCFFF",
+    "magenta": "#BB9AF7"
+  }
+}


### PR DESCRIPTION
Adds the **Storm** variant of Tokyo Night to the gallery, complementing the existing `folke/Tokyo Night` entry with the second most popular variant from [`folke/tokyonight.nvim`](https://github.com/folke/tokyonight.nvim).

## Why a separate entry

`folke/Tokyo Night` ships the canonical *Night* flavor (`#1A1B26`-family backgrounds). *Storm* is a meaningfully distinct variant — slightly lighter, slightly cooler — with its own dedicated palette in the upstream tokyonight.nvim repo. Both flavors have their fans, and following the precedent of `luisFilipePT/snow-storm.json` and `luisFilipePT/polar-night.json` (Nord variants published alongside other Nord work), this lives under its own author folder rather than presuming to extend `folke/`.

All colors are taken directly from the upstream `tokyonight.nvim` Storm palette. No invented values.

## Color reference

| Slot | Hex | Source |
|---|---|---|
| `background` | `#24283B` | storm `bg` |
| `backgroundSecondary` | `#1F2335` | storm `bg_dark` |
| `text` | `#C0CAF5` | `fg` |
| `selection` | `#364A82` | storm visual highlight |
| `loader` | `#7AA2F7` | `blue` |
| `red` | `#F7768E` | `red` |
| `orange` | `#FF9E64` | `orange` |
| `yellow` | `#E0AF68` | `yellow` |
| `green` | `#9ECE6A` | `green` |
| `blue` | `#7AA2F7` | `blue` |
| `purple` | `#7DCFFF` | `cyan` * |
| `magenta` | `#BB9AF7` | `magenta` (the iconic TN lavender) |

\* The Tokyo Night palette has two purples (`#9D7CD8` and `#BB9AF7`) sharing nearly the same hue (~261°). Mapping both into Raycast's `purple` and `magenta` accent slots collapses the categorical distinction at small sizes. Substituting Tokyo Night's `cyan` (`#7DCFFF`) into the `purple` slot keeps every color canonical to the upstream palette while restoring the spread that the accent system expects. The same convention is used by `ayu-mirage-owl.json`, which puts a cyan in the `blue` slot.