### PR TITLE
Add Serendipity and Sequoia Raycast themes

### DIFF
--- a/app/(navigation)/themes/themes/michael-andreuzza/sequoia-monochrome-dark.json
+++ b/app/(navigation)/themes/themes/michael-andreuzza/sequoia-monochrome-dark.json
@@ -1,0 +1,21 @@
+{
+  "author": "Micheal Andreuzza",
+  "authorUsername": "michael-andreuzza",
+  "version": 1,
+  "name": "Sequoia Monochrome Dark",
+  "appearance": "dark",
+  "colors": {
+    "background": "#0F1014",
+    "backgroundSecondary": "#111216",
+    "text": "#868690",
+    "selection": "#B6BAC8",
+    "loader": "#B6BAC8",
+    "red": "#999EB2",
+    "orange": "#B6BAC8",
+    "yellow": "#D3D5DE",
+    "green": "#626983",
+    "blue": "#7C829D",
+    "purple": "#D3D5DE",
+    "magenta": "#E2E4ED"
+  }
+}

--- a/app/(navigation)/themes/themes/michael-andreuzza/sequoia-monochrome-light.json
+++ b/app/(navigation)/themes/themes/michael-andreuzza/sequoia-monochrome-light.json
@@ -1,0 +1,21 @@
+{
+  "author": "Micheal Andreuzza",
+  "authorUsername": "michael-andreuzza",
+  "version": 1,
+  "name": "Sequoia Monochrome Light",
+  "appearance": "light",
+  "colors": {
+    "background": "#EDEEF2",
+    "backgroundSecondary": "#E2E3E8",
+    "text": "#282930",
+    "selection": "#454752",
+    "loader": "#454752",
+    "red": "#525666",
+    "orange": "#454752",
+    "yellow": "#50535E",
+    "green": "#2E3038",
+    "blue": "#5F6370",
+    "purple": "#50535E",
+    "magenta": "#25262D"
+  }
+}

--- a/app/(navigation)/themes/themes/michael-andreuzza/sequoia-moonlight-dark.json
+++ b/app/(navigation)/themes/themes/michael-andreuzza/sequoia-moonlight-dark.json
@@ -1,0 +1,21 @@
+{
+  "author": "Micheal Andreuzza",
+  "authorUsername": "michael-andreuzza",
+  "version": 1,
+  "name": "Sequoia Moonlight Dark",
+  "appearance": "dark",
+  "colors": {
+    "background": "#0F1014",
+    "backgroundSecondary": "#111216",
+    "text": "#868690",
+    "selection": "#FFBB88",
+    "loader": "#FFBB88",
+    "red": "#F58EE0",
+    "orange": "#FFBB88",
+    "yellow": "#9898A6",
+    "green": "#8EB6F5",
+    "blue": "#C58FFF",
+    "purple": "#9898A6",
+    "magenta": "#FDFDFE"
+  }
+}

--- a/app/(navigation)/themes/themes/michael-andreuzza/sequoia-moonlight-light.json
+++ b/app/(navigation)/themes/themes/michael-andreuzza/sequoia-moonlight-light.json
@@ -1,0 +1,21 @@
+{
+  "author": "Micheal Andreuzza",
+  "authorUsername": "michael-andreuzza",
+  "version": 1,
+  "name": "Sequoia Moonlight Light",
+  "appearance": "light",
+  "colors": {
+    "background": "#EDEEF2",
+    "backgroundSecondary": "#E2E3E8",
+    "text": "#282930",
+    "selection": "#D9884A",
+    "loader": "#D9884A",
+    "red": "#C94DA8",
+    "orange": "#D9884A",
+    "yellow": "#6A6A78",
+    "green": "#4A85D4",
+    "blue": "#9A5FD9",
+    "purple": "#6A6A78",
+    "magenta": "#282930"
+  }
+}

--- a/app/(navigation)/themes/themes/michael-andreuzza/sequoia-retro-dark.json
+++ b/app/(navigation)/themes/themes/michael-andreuzza/sequoia-retro-dark.json
@@ -1,0 +1,21 @@
+{
+  "author": "Micheal Andreuzza",
+  "authorUsername": "michael-andreuzza",
+  "version": 1,
+  "name": "Sequoia Retro Dark",
+  "appearance": "dark",
+  "colors": {
+    "background": "#0F1014",
+    "backgroundSecondary": "#111216",
+    "text": "#868690",
+    "selection": "#A27E57",
+    "loader": "#A27E57",
+    "red": "#829FA7",
+    "orange": "#A27E57",
+    "yellow": "#DA674B",
+    "green": "#648F68",
+    "blue": "#5C87A4",
+    "purple": "#DA674B",
+    "magenta": "#E8B246"
+  }
+}

--- a/app/(navigation)/themes/themes/michael-andreuzza/sequoia-retro-light.json
+++ b/app/(navigation)/themes/themes/michael-andreuzza/sequoia-retro-light.json
@@ -1,0 +1,21 @@
+{
+  "author": "Micheal Andreuzza",
+  "authorUsername": "michael-andreuzza",
+  "version": 1,
+  "name": "Sequoia Retro Light",
+  "appearance": "light",
+  "colors": {
+    "background": "#EDEEF2",
+    "backgroundSecondary": "#E2E3E8",
+    "text": "#282930",
+    "selection": "#8A6539",
+    "loader": "#8A6539",
+    "red": "#5F7982",
+    "orange": "#8A6539",
+    "yellow": "#BF5238",
+    "green": "#4A704E",
+    "blue": "#456A82",
+    "purple": "#BF5238",
+    "magenta": "#C99730"
+  }
+}

--- a/app/(navigation)/themes/themes/michael-andreuzza/serendipity-midnight.json
+++ b/app/(navigation)/themes/themes/michael-andreuzza/serendipity-midnight.json
@@ -1,0 +1,21 @@
+{
+  "author": "Micheal Andreuzza",
+  "authorUsername": "michael-andreuzza",
+  "version": 1,
+  "name": "Serendipity Midnight",
+  "appearance": "dark",
+  "colors": {
+    "background": "#151726",
+    "backgroundSecondary": "#1C1E2D",
+    "text": "#DEE0EF",
+    "selection": "#F8D2C9",
+    "loader": "#F8D2C9",
+    "red": "#EE8679",
+    "orange": "#F8D2C9",
+    "yellow": "#A78BFA",
+    "green": "#5BA2D0",
+    "blue": "#94B8FF",
+    "purple": "#A78BFA",
+    "magenta": "#9CCFD8"
+  }
+}

--- a/app/(navigation)/themes/themes/michael-andreuzza/serendipity-morning.json
+++ b/app/(navigation)/themes/themes/michael-andreuzza/serendipity-morning.json
@@ -1,0 +1,21 @@
+{
+  "author": "Micheal Andreuzza",
+  "authorUsername": "michael-andreuzza",
+  "version": 1,
+  "name": "Serendipity Morning",
+  "appearance": "light",
+  "colors": {
+    "background": "#F6F7FB",
+    "backgroundSecondary": "#EAEBEE",
+    "text": "#3F4363",
+    "selection": "#E58678",
+    "loader": "#E58678",
+    "red": "#C25A4D",
+    "orange": "#E58678",
+    "yellow": "#785FD0",
+    "green": "#2F7AAB",
+    "blue": "#6288D8",
+    "purple": "#785FD0",
+    "magenta": "#629AA5"
+  }
+}

--- a/app/(navigation)/themes/themes/michael-andreuzza/serendipity-sunset.json
+++ b/app/(navigation)/themes/themes/michael-andreuzza/serendipity-sunset.json
@@ -1,0 +1,21 @@
+{
+  "author": "Micheal Andreuzza",
+  "authorUsername": "michael-andreuzza",
+  "version": 1,
+  "name": "Serendipity Sunset",
+  "appearance": "dark",
+  "colors": {
+    "background": "#202231",
+    "backgroundSecondary": "#272938",
+    "text": "#DEE0EF",
+    "selection": "#D6B4B4",
+    "loader": "#D6B4B4",
+    "red": "#D1918F",
+    "orange": "#D6B4B4",
+    "yellow": "#A392DC",
+    "green": "#709BBD",
+    "blue": "#A0B6E8",
+    "purple": "#A392DC",
+    "magenta": "#AAC9D4"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds 3 Serendipity themes (Midnight, Morning, Sunset) under `michael-andreuzza/`
- Adds 6 Sequoia themes (Moonlight, Monochrome, Retro × dark/light) under `michael-andreuzza/`
- Themes are part of the [Serendipity](https://github.com/Serendipity-Theme/vs-code) and [Sequoia](https://github.com/Sequoia-Theme/vs-code) design systems

## Test plan
- [ ] Verify themes appear on themes.ray.so after deploy
- [ ] Import each theme via "Add to Raycast" on themes.ray.so
- [ ] Confirm light/dark appearance matches source palettes


Made with [Cursor](https://cursor.com)