### PR TITLE
Fix remaining Dependabot postcss alert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -70,7 +70,7 @@
         "eslint-config-next": "16.2.6",
         "husky": "^8.0.3",
         "lint-staged": "^13.1.0",
-        "postcss": "^8.4.38",
+        "postcss": "8.5.15",
         "postcss-nested": "^6.0.0",
         "stylelint": "^14.11.0",
         "stylelint-config-idiomatic-order": "^9.0.0",
@@ -10003,52 +10003,6 @@
         "sass": {
           "optional": true
         }
-      }
-    },
-    "node_modules/next/node_modules/nanoid": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/node-releases": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "eslint-config-next": "16.2.6",
     "husky": "^8.0.3",
     "lint-staged": "^13.1.0",
-    "postcss": "^8.4.38",
+    "postcss": "8.5.15",
     "postcss-nested": "^6.0.0",
     "stylelint": "^14.11.0",
     "stylelint-config-idiomatic-order": "^9.0.0",
@@ -90,6 +90,7 @@
     "@babel/plugin-transform-modules-systemjs": "7.29.7",
     "fast-uri": "3.1.2",
     "lodash": "^4.18.1",
-    "lodash-es": "^4.18.1"
+    "lodash-es": "^4.18.1",
+    "postcss": "$postcss"
   }
 }


### PR DESCRIPTION
## Summary

After merging #447 (WEB-483), one open Dependabot alert remained:

- **#79** — `postcss` `< 8.5.10` (medium), from Next.js bundling `postcss@8.4.31`

This PR pins `postcss@8.5.15` and adds an npm override (`"postcss": "$postcss"`) so Next uses the same patched version. `npm audit` reports 0 vulnerabilities.

## Testing

- `npm audit` — 0 vulnerabilities
- `npm run build` — passes

Linear: https://linear.app/raycast/issue/WEB-483