### PR TITLE
fix(icon-generator): handle oversized URLs in onCopyShareUrl

### DIFF
--- a/app/(navigation)/icon/icon-generator.tsx
+++ b/app/(navigation)/icon/icon-generator.tsx
@@ -439,14 +439,28 @@ export const IconGenerator = () => {
       Object.entries(settings).map(([key, value]) => [key, String(value)]),
     ).toString()}`;
 
-    let urlToCopy = url;
-    const encodedUrl = encodeURIComponent(url);
-    const response = await fetch(`https://ray.so/api/shorten-url?url=${encodedUrl}&ref=icons`).then((res) =>
-      res.json(),
-    );
+    // The shorten-url endpoint rejects URLs above ~2KB. Custom images get serialized
+    // into the URL as base64 and blow past that ceiling, which previously left the
+    // "Copying URL to clipboard…" toast stuck with no error. Skip the shorten step
+    // for those cases and copy the unshortened URL with a clarifying message.
+    if (url.length > 2000) {
+      navigator.clipboard.writeText(url);
+      showInfoMessage("URL copied (too long to shorten — custom images stay inline)", true);
+      return;
+    }
 
-    if (response.link) {
-      urlToCopy = response.link;
+    let urlToCopy = url;
+    try {
+      const encodedUrl = encodeURIComponent(url);
+      const response = await fetch(`https://ray.so/api/shorten-url?url=${encodedUrl}&ref=icons`);
+      if (response.ok) {
+        const data = await response.json();
+        if (data.link) {
+          urlToCopy = data.link;
+        }
+      }
+    } catch {
+      // Network/CORS failure — fall through to the unshortened URL below.
     }
 
     navigator.clipboard.writeText(urlToCopy);


### PR DESCRIPTION
Closes #444.

When a user uploads a custom image into the icon editor and clicks "Copy URL", the loading toast appears and never resolves: the URL embeds the image as base64 in search params, the shorten-url endpoint rejects requests above ~2KB, the `fetch().then(res.json())` chain throws on the network/CORS failure, and the `clipboard.writeText` line is never reached.

The fix in `app/(navigation)/icon/icon-generator.tsx:onCopyShareUrl`:

1. Pre-check the URL length. If above 2000 chars, skip the shorten request, copy the unshortened URL, and surface a toast that explains why ("URL copied (too long to shorten — custom images stay inline)").
2. Wrap the shorten fetch in try/catch + check `response.ok`. Any network, CORS, or non-OK response falls through to copying the unshortened URL, so the clipboard is always written and the loading toast always resolves.

The 2KB threshold matches the issue reporter's "Staying under 2,000 characters is safest for compatibility" note and is comfortably below the practical URL length ceiling on every major browser.

### Manual verification

- Default icon → URL is short → shortens normally, toast says "URL copied to clipboard". (unchanged)
- Upload a custom image → URL is large → toast says "URL copied (too long to shorten — custom images stay inline)", clipboard holds the full unshortened ray.so/icon?... URL that opens the editor in the same state.
- Take the shorten endpoint offline (block via DevTools) → toast resolves with "URL copied to clipboard", clipboard holds the unshortened URL. No silent stall.