### PR TITLE
Update GitHub pull request quicklinks

### DIFF
--- a/app/(navigation)/quicklinks/quicklinks.ts
+++ b/app/(navigation)/quicklinks/quicklinks.ts
@@ -146,9 +146,9 @@ const development: Quicklink[] = [
   },
   {
     id: "githubPullRequests",
-    name: "GitHub Pull Requests (Created)",
-    link: "https://github.com/pulls",
-    description: "View your created GitHub Pull Requests",
+    name: "GitHub Pull Requests (Authored by Me)",
+    link: "https://github.com/pulls/authored",
+    description: "View your authored GitHub Pull Requests",
     author: {
       name: "a2c",
       link: "https://github.com/atzzCokeK",
@@ -156,8 +156,8 @@ const development: Quicklink[] = [
   },
   {
     id: "githubReviewRequestedPullRequests",
-    name: "GitHub Pull Requests (Review Requested)",
-    link: "https://github.com/pulls/review-requested",
+    name: "GitHub Pull Requests (Review Requests)",
+    link: "https://github.com/pulls/reviews",
     description: "View GitHub Pull Requests where your review is requested",
     author: {
       name: "a2c",


### PR DESCRIPTION
## Summary
- Update the GitHub Pull Requests quicklinks to the current `/pulls/authored` and `/pulls/reviews` paths.
- Refresh the quicklink labels and descriptions to match the current GitHub views: "Authored by me" and "Review requests".

## Background
PR #392 added two GitHub Pull Requests quicklinks for the global GitHub PR views:

- created pull requests: `https://github.com/pulls`
- review-requested pull requests: `https://github.com/pulls/review-requested`

GitHub has since changed the path and visible wording around these global PR views. The current URLs are:

- Authored by me: `https://github.com/pulls/authored`
- Review requests: `https://github.com/pulls/reviews`

The old `review-requested` path no longer matches the current GitHub route, so this keeps the quicklinks aligned with the current GitHub UI.

## GitHub Reference
I could not find a GitHub Changelog entry that explicitly documents this route change. The closest official reference is the GitHub Docs page for issue and pull request search qualifiers, which documents the current terminology behind these views:

- `author:@me` matches issues and pull requests you have authored.
- `user-review-requested:@me` matches pull requests that you have directly been asked to review.

Reference: https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests

## Validation
- `npx eslint 'app/(navigation)/quicklinks/quicklinks.ts'`
- `npm run lint` fails on existing unrelated lint errors in code, icon, presets, and log files.
