### PR TITLE
Harden shorten-url/OG API routes and fix drag-deselection in prompts/snippets

### DIFF
--- a/app/(navigation)/prompts/[[...slug]]/prompts.tsx
+++ b/app/(navigation)/prompts/[[...slug]]/prompts.tsx
@@ -78,7 +78,7 @@ export function Prompts({ models, extensions }: Props) {
     const removedPrompts = extractPrompts(removed, categories);
 
     setSelectedPrompts((prevPrompts) => {
-      const prompts = [...prevPrompts];
+      let prompts = [...prevPrompts];
 
       addedPrompts.forEach((prompt) => {
         if (!prompt) {
@@ -91,7 +91,7 @@ export function Prompts({ models, extensions }: Props) {
       });
 
       removedPrompts.forEach((prompt) => {
-        return prompts.filter((s) => s?.id !== prompt?.id);
+        prompts = prompts.filter((s) => s?.id !== prompt?.id);
       });
 
       return prompts;

--- a/app/(navigation)/prompts/shared/shared.tsx
+++ b/app/(navigation)/prompts/shared/shared.tsx
@@ -89,7 +89,7 @@ export function Shared({ prompts, extensions }: { prompts: Prompt[]; extensions:
     const removedPrompts = extractPrompts(removed, categories);
 
     setSelectedPrompts((prevPrompts) => {
-      const prompts = [...prevPrompts];
+      let prompts = [...prevPrompts];
 
       addedPrompts.forEach((prompt) => {
         if (!prompt) {
@@ -102,7 +102,7 @@ export function Shared({ prompts, extensions }: { prompts: Prompt[]; extensions:
       });
 
       removedPrompts.forEach((prompt) => {
-        return prompts.filter((s) => s?.id !== prompt?.id);
+        prompts = prompts.filter((s) => s?.id !== prompt?.id);
       });
 
       return prompts;

--- a/app/(navigation)/quicklinks/og/route.tsx
+++ b/app/(navigation)/quicklinks/og/route.tsx
@@ -9,6 +9,20 @@ import { Base64 } from "js-base64";
 
 export const runtime = "edge";
 
+// Icon URLs are only ever generated via Google's favicon service (see shared/page.tsx),
+// so anything else is rejected to prevent the edge runtime from fetching arbitrary URLs.
+function isAllowedIconUrl(value: string | null): value is string {
+  if (!value) {
+    return false;
+  }
+  try {
+    const url = new URL(value);
+    return url.protocol === "https:" && url.hostname === "www.google.com" && url.pathname === "/s2/favicons";
+  } catch {
+    return false;
+  }
+}
+
 export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url);
@@ -19,8 +33,9 @@ export async function GET(request: Request) {
     const ellipsedDescription = description.length > 120 ? `${description.slice(0, 120)}...` : description;
     const hasIconName = searchParams.has("iconName");
     const iconName = searchParams.get("iconName") || "link";
-    const hasIconUrl = searchParams.has("iconUrl");
-    const iconUrl = searchParams.get("iconUrl");
+    const iconUrlParam = searchParams.get("iconUrl");
+    const iconUrl = isAllowedIconUrl(iconUrlParam) ? iconUrlParam : null;
+    const hasIconUrl = iconUrl !== null;
 
     const interRegular = await fetch(new URL(`./Inter-Regular.ttf`, import.meta.url)).then((res) => res.arrayBuffer());
     const interSemiBold = await fetch(new URL(`./Inter-SemiBold.ttf`, import.meta.url)).then((res) =>

--- a/app/(navigation)/snippets/[[...slug]]/snippets.tsx
+++ b/app/(navigation)/snippets/[[...slug]]/snippets.tsx
@@ -108,7 +108,7 @@ export default function Snippets() {
     const removedSnippets = extractSnippets(removed, snippetGroups);
 
     setSelectedSnippets((prevSnippets) => {
-      const snippets = [...prevSnippets];
+      let snippets = [...prevSnippets];
 
       addedSnippets.forEach((snippet) => {
         if (!snippet) {
@@ -121,7 +121,7 @@ export default function Snippets() {
       });
 
       removedSnippets.forEach((snippet) => {
-        return snippets.filter((s) => s?.id !== snippet?.id);
+        snippets = snippets.filter((s) => s?.id !== snippet?.id);
       });
 
       return snippets;

--- a/app/(navigation)/snippets/shared/shared.tsx
+++ b/app/(navigation)/snippets/shared/shared.tsx
@@ -82,7 +82,7 @@ export function Shared({ snippets }: { snippets: Snippet[] }) {
     const removedSnippets = extractSnippets(removed, categories);
 
     setSelectedSnippets((prevSnippets) => {
-      const snippets = [...prevSnippets];
+      let snippets = [...prevSnippets];
 
       addedSnippets.forEach((snippet) => {
         if (!snippet) {
@@ -95,7 +95,7 @@ export function Shared({ snippets }: { snippets: Snippet[] }) {
       });
 
       removedSnippets.forEach((snippet) => {
-        return snippets.filter((s) => s?.id !== snippet?.id);
+        snippets = snippets.filter((s) => s?.id !== snippet?.id);
       });
 
       return snippets;

--- a/app/api/shorten-url/route.ts
+++ b/app/api/shorten-url/route.ts
@@ -24,13 +24,11 @@ const getTagId = (ref: refProps) => {
   return ref ? tagIdsByRef[ref] : undefined;
 };
 
-function isAllowedHostname(hostname: string) {
+// requestHostname covers preview deployments: they may only shorten links
+// pointing to themselves, so no *.vercel.app wildcard is needed.
+function isAllowedHostname(hostname: string, requestHostname: string) {
   return (
-    hostname === "ray.so" ||
-    hostname.endsWith(".ray.so") ||
-    hostname === "raycastapp.vercel.app" ||
-    hostname.endsWith("-raycastapp.vercel.app") ||
-    hostname === "localhost"
+    hostname === "ray.so" || hostname.endsWith(".ray.so") || hostname === "localhost" || hostname === requestHostname
   );
 }
 
@@ -60,7 +58,7 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: "Invalid URL" }, { status: 400 });
   }
 
-  if (!isAllowedHostname(url.hostname)) {
+  if (!isAllowedHostname(url.hostname, req.nextUrl.hostname)) {
     return NextResponse.json({ error: "Unable to shorten this link" }, { status: 400 });
   }
 

--- a/app/api/shorten-url/route.ts
+++ b/app/api/shorten-url/route.ts
@@ -24,38 +24,54 @@ const getTagId = (ref: refProps) => {
   return ref ? tagIdsByRef[ref] : undefined;
 };
 
+function isAllowedHostname(hostname: string) {
+  return (
+    hostname === "ray.so" ||
+    hostname.endsWith(".ray.so") ||
+    hostname === "raycastapp.vercel.app" ||
+    hostname.endsWith("-raycastapp.vercel.app") ||
+    hostname === "localhost"
+  );
+}
+
 export async function GET(req: NextRequest) {
   const searchParams = req.nextUrl.searchParams;
   const urlQuery = searchParams.get("url");
   const refQuery = searchParams.get("ref");
 
-  const url = new URL(urlQuery as string);
-  const tagId = getTagId(refQuery as refProps);
-
-  if (!url) {
-    return NextResponse.json({ error: "Missing URL" });
+  if (!urlQuery) {
+    return NextResponse.json({ error: "Missing URL" }, { status: 400 });
   }
 
   if (!refQuery) {
-    return NextResponse.json({ error: "Missing ref" });
+    return NextResponse.json({ error: "Missing ref" }, { status: 400 });
   }
+
+  const tagId = getTagId(refQuery as refProps);
 
   if (!tagId) {
-    return NextResponse.json({ error: "Invalid ref" });
+    return NextResponse.json({ error: "Invalid ref" }, { status: 400 });
   }
 
-  if (
-    url.hostname.endsWith("ray.so") ||
-    url.hostname.includes("raycastapp.vercel.app") ||
-    url.hostname === "localhost"
-  ) {
+  let url: URL;
+  try {
+    url = new URL(urlQuery);
+  } catch {
+    return NextResponse.json({ error: "Invalid URL" }, { status: 400 });
+  }
+
+  if (!isAllowedHostname(url.hostname)) {
+    return NextResponse.json({ error: "Unable to shorten this link" }, { status: 400 });
+  }
+
+  try {
     const link = await dub.links.create({
       url: url.href,
       domain: "go.ray.so",
       tagIds: [tagId],
     });
     return NextResponse.json({ link: `https://ray.so/${link.key}` });
+  } catch {
+    return NextResponse.json({ error: "Unable to shorten this link" }, { status: 500 });
   }
-
-  return NextResponse.json({ error: "Unable to shorten this link" }, { status: 400 });
 }


### PR DESCRIPTION
## What changed

### `/api/shorten-url` hardening
- **Crash fix:** `new URL(urlQuery as string)` ran before the missing-param checks, so a missing or malformed `url` threw an unhandled 500. Params are now validated first and URL parsing is wrapped in try/catch, returning a 400 with an error message.
- **Hostname allowlist bypass:** `url.hostname.endsWith("ray.so")` matched domains like `evilray.so`, and `.includes("raycastapp.vercel.app")` matched any hostname containing that substring. Since the endpoint is unauthenticated and CORS-wildcarded, anyone could mint trusted `go.ray.so` short links pointing at arbitrary domains — a phishing vector. The check is now an exact allowlist: `ray.so`, `*.ray.so`, `localhost`, plus the request's own hostname — the latter keeps preview deployments working (they may shorten links pointing to themselves) without trusting any `vercel.app` pattern that a hostile team name could match.
- Error responses now return real 4xx/5xx status codes instead of 200, and `dub.links.create` failures are caught instead of crashing the handler.

### Quicklinks OG route SSRF fix
- The `iconUrl` query param was rendered into an `@vercel/og` `<img>` with no validation, letting anyone coerce the edge runtime into fetching arbitrary URLs. All legitimate `iconUrl` values are generated via Google's favicon service (see `quicklinks/shared/page.tsx`), so the param is now validated against exactly that (`https://www.google.com/s2/favicons`); anything else falls back to the default link icon.

### Drag-deselection bug in prompts and snippets (4 files)
- The selection updater did `removedPrompts.forEach((prompt) => { return prompts.filter(...) })`, discarding the filtered array — so drag-deselecting could never remove items. The quicklinks implementation already had the fix (`quicklinkIds = quicklinkIds.filter(...)`) but it was never backported. Applied the same pattern to `prompts/[[...slug]]`, `prompts/shared`, `snippets/[[...slug]]`, and `snippets/shared`.

## Notes for reviewers
- `npm run type-check` passes (0 errors) and ESLint is clean on all changed files; `next build` succeeds.
- The same-hostname rule relies on Vercel routing requests by Host header, so a request reaching this deployment always carries the deployment's own hostname — an attacker can't spoof it to allowlist a foreign domain.
- Behavior change: invalid shorten-url requests now get proper 400/500 status codes instead of 200 + error body. `ExportButton.tsx` and other callers only check for `link`/`error` fields in the JSON, so no client changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)