### PR TITLE
Fix Raycast import flow: auto-detect and prioritize Raycast v2 over v1

### DIFF
--- a/app/(navigation)/presets/[[...slug]]/presets.tsx
+++ b/app/(navigation)/presets/[[...slug]]/presets.tsx
@@ -87,7 +87,7 @@ export default function Presets({ models, extensions }: Props) {
           <InfoDialog />
           <ButtonGroup>
             <Button variant="primary" disabled>
-              <PlusCircleIcon /> Add to Raycast v1
+              <PlusCircleIcon /> Add to Raycast
             </Button>
 
             <Button variant="primary" disabled aria-label="Export options">

--- a/app/(navigation)/presets/components/PresetDetail.tsx
+++ b/app/(navigation)/presets/components/PresetDetail.tsx
@@ -42,7 +42,6 @@ import { renderSafePromptContent } from "@/utils/sanitizePromptContent";
 import { isTouchDevice } from "../utils/isTouchDevice";
 import { shortenUrl } from "@/utils/common";
 import { toast } from "@/components/toast";
-import { type RaycastImportVersion, useRaycastImportVersion } from "@/app/RaycastFlavor";
 
 type PresetPageProps = {
   preset: Preset;
@@ -59,7 +58,6 @@ export function PresetDetail({ preset, relatedPresets, models, extensions }: Pre
   const modelSupportsImageGen = modelObj?.abilities?.image_generation;
   const router = useRouter();
   const [isTouch, setIsTouch] = React.useState<boolean>();
-  const [raycastImportVersion, setRaycastImportVersion] = useRaycastImportVersion();
 
   const [showToast, setShowToast] = React.useState(false);
   const [toastMessage, setToastMessage] = React.useState("");
@@ -84,16 +82,9 @@ export function PresetDetail({ preset, relatedPresets, models, extensions }: Pre
     }
   }, [showToast]);
 
-  const handleAddToRaycast = React.useCallback(
-    (importVersion: RaycastImportVersion = raycastImportVersion) => {
-      if (!isTouch) {
-        setRaycastImportVersion(importVersion);
-      }
-
-      return addToRaycast(router, preset, isTouch, importVersion);
-    },
-    [router, preset, isTouch, raycastImportVersion, setRaycastImportVersion],
-  );
+  const handleAddToRaycast = React.useCallback(() => {
+    return addToRaycast(router, preset, isTouch);
+  }, [router, preset, isTouch]);
 
   const handleCopyInstructions = () => {
     copy(instructions);
@@ -209,7 +200,7 @@ export function PresetDetail({ preset, relatedPresets, models, extensions }: Pre
           <InfoDialog />
           <ButtonGroup>
             <Button variant="primary" onClick={() => handleAddToRaycast()}>
-              <PlusCircleIcon /> Add to Raycast {raycastImportVersion}
+              <PlusCircleIcon /> Add to Raycast
             </Button>
 
             <DropdownMenu open={actionsOpen} onOpenChange={setActionsOpen}>
@@ -219,16 +210,6 @@ export function PresetDetail({ preset, relatedPresets, models, extensions }: Pre
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
-                {raycastImportVersion === "v1" && (
-                  <DropdownMenuItem onSelect={() => handleAddToRaycast("v2")}>
-                    <PlusCircleIcon /> Add to Raycast v2
-                  </DropdownMenuItem>
-                )}
-                {raycastImportVersion === "v2" && (
-                  <DropdownMenuItem onSelect={() => handleAddToRaycast("v1")}>
-                    <PlusCircleIcon /> Add to Raycast v1
-                  </DropdownMenuItem>
-                )}
                 <DropdownMenuItem onSelect={() => handleDownload()}>
                   <DownloadIcon /> Download JSON
                   <span className="inline-flex gap-1 items-center ml-auto pl-2">

--- a/app/(navigation)/presets/utils/actions.ts
+++ b/app/(navigation)/presets/utils/actions.ts
@@ -3,7 +3,7 @@ import { Preset } from "../presets";
 import { AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
 import { BASE_URL } from "@/utils/common";
 import { Model } from "@/api/ai";
-import { getRaycastFlavor, setRaycastImportVersion, type RaycastImportVersion } from "@/app/RaycastFlavor";
+import { getRaycastFlavor } from "@/app/RaycastFlavor";
 
 function prepareModel(model: Model) {
   if (model && /^".*"$/.test(model)) {
@@ -68,23 +68,14 @@ export function copyUrl(preset: Preset) {
   copy(makeUrl(preset));
 }
 
-export async function addToRaycast(
-  router: AppRouterInstance,
-  preset: Preset,
-  isTouch?: boolean,
-  importVersion?: RaycastImportVersion,
-) {
+export async function addToRaycast(router: AppRouterInstance, preset: Preset, isTouch?: boolean) {
   const queryString = makeQueryString(preset);
 
   // For mobile, use window.location.href directly as it's more reliable
   if (isTouch) {
     window.location.href = `raycast://presets/import?${queryString}`;
   } else {
-    if (importVersion) {
-      setRaycastImportVersion(importVersion);
-    }
-
-    const raycastProtocol = await getRaycastFlavor(importVersion);
+    const raycastProtocol = await getRaycastFlavor();
     const url = `${raycastProtocol}://presets/import?${queryString}`;
 
     // For desktop, use router.replace

--- a/app/(navigation)/prompts/[[...slug]]/prompts.tsx
+++ b/app/(navigation)/prompts/[[...slug]]/prompts.tsx
@@ -40,7 +40,6 @@ import { TooltipTrigger } from "@/components/tooltip";
 import { Extension } from "@/api/store";
 import { AIExtension } from "@/components/ai-extension";
 import { renderSafePromptContent } from "@/utils/sanitizePromptContent";
-import { type RaycastImportVersion, useRaycastImportVersion } from "@/app/RaycastFlavor";
 
 type Props = {
   models: AiModel[];
@@ -60,7 +59,6 @@ export function Prompts({ models, extensions }: Props) {
 
   const [actionsOpen, setActionsOpen] = React.useState(false);
   const [isTouch, setIsTouch] = React.useState<boolean>();
-  const [raycastImportVersion, setRaycastImportVersion] = useRaycastImportVersion();
 
   const onStart = ({ event, selection }: SelectionEvent) => {
     if (!isTouch && !event?.ctrlKey && !event?.metaKey) {
@@ -134,16 +132,9 @@ export function Prompts({ models, extensions }: Props) {
     setToastMessage("Copied to clipboard");
   }, []);
 
-  const handleAddToRaycast = React.useCallback(
-    (importVersion: RaycastImportVersion = raycastImportVersion) => {
-      if (!isTouch) {
-        setRaycastImportVersion(importVersion);
-      }
-
-      return addToRaycast(router, selectedPrompts, isTouch, importVersion);
-    },
-    [router, selectedPrompts, isTouch, raycastImportVersion, setRaycastImportVersion],
-  );
+  const handleAddToRaycast = React.useCallback(() => {
+    return addToRaycast(router, selectedPrompts, isTouch);
+  }, [router, selectedPrompts, isTouch]);
 
   React.useEffect(() => {
     setIsTouch(isTouchDevice());
@@ -216,7 +207,7 @@ export function Prompts({ models, extensions }: Props) {
           <InfoDialog />
           <ButtonGroup>
             <Button variant="primary" disabled={selectedPrompts.length === 0} onClick={() => handleAddToRaycast()}>
-              <PlusCircleIcon /> Add to Raycast {raycastImportVersion}
+              <PlusCircleIcon /> Add to Raycast
             </Button>
 
             <DropdownMenu open={actionsOpen} onOpenChange={setActionsOpen}>
@@ -226,16 +217,6 @@ export function Prompts({ models, extensions }: Props) {
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
-                {raycastImportVersion === "v1" && (
-                  <DropdownMenuItem disabled={selectedPrompts.length === 0} onSelect={() => handleAddToRaycast("v2")}>
-                    <PlusCircleIcon /> Add to Raycast v2
-                  </DropdownMenuItem>
-                )}
-                {raycastImportVersion === "v2" && (
-                  <DropdownMenuItem disabled={selectedPrompts.length === 0} onSelect={() => handleAddToRaycast("v1")}>
-                    <PlusCircleIcon /> Add to Raycast v1
-                  </DropdownMenuItem>
-                )}
                 <DropdownMenuItem disabled={selectedPrompts.length === 0} onSelect={() => handleDownload()}>
                   <DownloadIcon /> Download JSON
                   <Kbds>
@@ -319,7 +300,7 @@ export function Prompts({ models, extensions }: Props) {
 
                     <div className={styles.summaryControls}>
                       <Button onClick={() => handleAddToRaycast()} variant="primary">
-                        Add to Raycast {raycastImportVersion}
+                        Add to Raycast
                       </Button>
 
                       <Button onClick={() => setSelectedPrompts([])}>Clear selected</Button>

--- a/app/(navigation)/prompts/components/Instructions.tsx
+++ b/app/(navigation)/prompts/components/Instructions.tsx
@@ -15,11 +15,11 @@ export function Instructions() {
       <h3 className={styles.title}>Install AI Commands</h3>
       <p className={styles.description}>
         Select a prompt by clicking on it. Hold <kbd data-variant="small">⌘</kbd> to select multiple. Click{" "}
-        <strong>Add to Raycast v1</strong> to import them directly.
+        <strong>Add to Raycast</strong> to import them directly.
       </p>
 
       <Button variant="primary" disabled>
-        Add to Raycast v1
+        Add to Raycast
       </Button>
     </div>
   );

--- a/app/(navigation)/prompts/shared/shared.tsx
+++ b/app/(navigation)/prompts/shared/shared.tsx
@@ -44,7 +44,6 @@ import { Extension } from "@/api/store";
 import { AIExtension } from "@/components/ai-extension";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/tooltip";
 import { renderSafePromptContent } from "@/utils/sanitizePromptContent";
-import { type RaycastImportVersion, useRaycastImportVersion } from "@/app/RaycastFlavor";
 
 export function Shared({ prompts, extensions }: { prompts: Prompt[]; extensions: Extension[] }) {
   const router = useRouter();
@@ -54,7 +53,6 @@ export function Shared({ prompts, extensions }: { prompts: Prompt[]; extensions:
 
   const [selectedPrompts, setSelectedPrompts] = React.useState([...prompts]);
   const isTouch = React.useMemo(() => (typeof window !== "undefined" ? isTouchDevice() : false), []);
-  const [raycastImportVersion, setRaycastImportVersion] = useRaycastImportVersion();
 
   const [isClient, setIsClient] = React.useState(false);
 
@@ -134,16 +132,9 @@ export function Shared({ prompts, extensions }: { prompts: Prompt[]; extensions:
     setCopied(true);
   }, [selectedPrompts]);
 
-  const handleAddToRaycast = React.useCallback(
-    (importVersion: RaycastImportVersion = raycastImportVersion) => {
-      if (!isTouch) {
-        setRaycastImportVersion(importVersion);
-      }
-
-      return addToRaycast(router, selectedPrompts, isTouch, importVersion);
-    },
-    [router, selectedPrompts, isTouch, raycastImportVersion, setRaycastImportVersion],
-  );
+  const handleAddToRaycast = React.useCallback(() => {
+    return addToRaycast(router, selectedPrompts, isTouch);
+  }, [router, selectedPrompts, isTouch]);
 
   const handleCopyText = React.useCallback((prompt: Prompt) => {
     copy(prompt.prompt);
@@ -215,7 +206,7 @@ export function Shared({ prompts, extensions }: { prompts: Prompt[]; extensions:
           <InfoDialog />
           <ButtonGroup>
             <Button variant="primary" disabled={selectedPrompts.length === 0} onClick={() => handleAddToRaycast()}>
-              <PlusCircleIcon /> Add to Raycast {raycastImportVersion}
+              <PlusCircleIcon /> Add to Raycast
             </Button>
 
             <DropdownMenu open={actionsOpen} onOpenChange={setActionsOpen}>
@@ -225,16 +216,6 @@ export function Shared({ prompts, extensions }: { prompts: Prompt[]; extensions:
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
-                {raycastImportVersion === "v1" && (
-                  <DropdownMenuItem disabled={selectedPrompts.length === 0} onSelect={() => handleAddToRaycast("v2")}>
-                    <PlusCircleIcon /> Add to Raycast v2
-                  </DropdownMenuItem>
-                )}
-                {raycastImportVersion === "v2" && (
-                  <DropdownMenuItem disabled={selectedPrompts.length === 0} onSelect={() => handleAddToRaycast("v1")}>
-                    <PlusCircleIcon /> Add to Raycast v1
-                  </DropdownMenuItem>
-                )}
                 <DropdownMenuItem disabled={selectedPrompts.length === 0} onSelect={() => handleDownload()}>
                   <DownloadIcon /> Download JSON
                   <Kbds>

--- a/app/(navigation)/prompts/utils/actions.ts
+++ b/app/(navigation)/prompts/utils/actions.ts
@@ -3,7 +3,7 @@ import { Prompt } from "../prompts";
 import { AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
 import { BASE_URL } from "@/utils/common";
 import { Model } from "@/api/ai";
-import { getRaycastFlavor, setRaycastImportVersion, type RaycastImportVersion } from "@/app/RaycastFlavor";
+import { getRaycastFlavor } from "@/app/RaycastFlavor";
 
 function prepareModel(model?: string) {
   if (model && /^".*"$/.test(model)) {
@@ -68,23 +68,14 @@ export function copyUrl(prompts: Prompt[]) {
   copy(makeUrl(prompts));
 }
 
-export async function addToRaycast(
-  router: AppRouterInstance,
-  prompts: Prompt[],
-  isTouch?: boolean,
-  importVersion?: RaycastImportVersion,
-) {
+export async function addToRaycast(router: AppRouterInstance, prompts: Prompt[], isTouch?: boolean) {
   const queryString = makeQueryString(prompts);
 
   // For mobile, use window.location.href directly as it's more reliable
   if (isTouch) {
     window.location.href = `raycast://prompts/import?${queryString}`;
   } else {
-    if (importVersion) {
-      setRaycastImportVersion(importVersion);
-    }
-
-    const raycastProtocol = await getRaycastFlavor(importVersion);
+    const raycastProtocol = await getRaycastFlavor();
     const url = `${raycastProtocol}://prompts/import?${queryString}`;
 
     // For desktop, use router.replace

--- a/app/(navigation)/quicklinks/[[...slug]]/quicklinks.tsx
+++ b/app/(navigation)/quicklinks/[[...slug]]/quicklinks.tsx
@@ -33,7 +33,7 @@ import { QuicklinkComponent } from "../components/quicklink";
 import { shortenUrl } from "@/utils/common";
 import { toast } from "@/components/toast";
 import { Input, InputSlot } from "@/components/input";
-import { getRaycastFlavor, type RaycastImportVersion, useRaycastImportVersion } from "@/app/RaycastFlavor";
+import { getRaycastFlavor } from "@/app/RaycastFlavor";
 
 function withRaycastProtocol(link: string, protocol: string) {
   if (!protocol) return link;
@@ -94,15 +94,14 @@ export function Quicklinks() {
 
   const [actionsOpen, setActionsOpen] = React.useState(false);
   const [isTouch, setIsTouch] = React.useState<boolean>();
-  const [raycastImportVersion, setRaycastImportVersion] = useRaycastImportVersion();
 
   React.useEffect(() => {
     async function fetchRaycastProtocol() {
-      const protocol = await getRaycastFlavor(raycastImportVersion);
+      const protocol = await getRaycastFlavor();
       setRaycastProtocol(protocol);
     }
     fetchRaycastProtocol();
-  }, [raycastImportVersion]);
+  }, []);
 
   const onStart = ({ event, selection }: SelectionEvent) => {
     if (!isTouch && !event?.ctrlKey && !event?.metaKey) {
@@ -166,16 +165,9 @@ export function Quicklinks() {
     );
   }, [selectedQuicklinks]);
 
-  const handleAddToRaycast = React.useCallback(
-    (importVersion: RaycastImportVersion = raycastImportVersion) => {
-      if (!isTouch) {
-        setRaycastImportVersion(importVersion);
-      }
-
-      return addToRaycast(router, selectedQuicklinks, isTouch, importVersion);
-    },
-    [router, selectedQuicklinks, isTouch, raycastImportVersion, setRaycastImportVersion],
-  );
+  const handleAddToRaycast = React.useCallback(() => {
+    return addToRaycast(router, selectedQuicklinks, isTouch);
+  }, [router, selectedQuicklinks, isTouch]);
 
   React.useEffect(() => {
     setIsTouch(isTouchDevice());
@@ -241,7 +233,7 @@ export function Quicklinks() {
           <InfoDialog />
           <ButtonGroup>
             <Button variant="primary" disabled={selectedQuicklinks.length === 0} onClick={() => handleAddToRaycast()}>
-              <PlusCircleIcon /> Add to Raycast {raycastImportVersion}
+              <PlusCircleIcon /> Add to Raycast
             </Button>
 
             <DropdownMenu open={actionsOpen} onOpenChange={setActionsOpen}>
@@ -251,22 +243,6 @@ export function Quicklinks() {
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
-                {raycastImportVersion === "v1" && (
-                  <DropdownMenuItem
-                    disabled={selectedQuicklinks.length === 0}
-                    onSelect={() => handleAddToRaycast("v2")}
-                  >
-                    <PlusCircleIcon /> Add to Raycast v2
-                  </DropdownMenuItem>
-                )}
-                {raycastImportVersion === "v2" && (
-                  <DropdownMenuItem
-                    disabled={selectedQuicklinks.length === 0}
-                    onSelect={() => handleAddToRaycast("v1")}
-                  >
-                    <PlusCircleIcon /> Add to Raycast v1
-                  </DropdownMenuItem>
-                )}
                 <DropdownMenuItem disabled={selectedQuicklinks.length === 0} onSelect={() => handleDownload()}>
                   <DownloadIcon /> Download JSON
                   <Kbds>
@@ -367,7 +343,7 @@ export function Quicklinks() {
 
                     <div className={styles.summaryControls}>
                       <Button onClick={() => handleAddToRaycast()} variant="primary">
-                        Add to Raycast {raycastImportVersion}
+                        Add to Raycast
                       </Button>
 
                       <Button onClick={() => setSelectedQuicklinkIds([])}>Clear selected</Button>

--- a/app/(navigation)/quicklinks/components/Instructions.tsx
+++ b/app/(navigation)/quicklinks/components/Instructions.tsx
@@ -15,11 +15,11 @@ export function Instructions() {
       <h3 className={styles.title}>Install Quicklinks</h3>
       <p className={styles.description}>
         Select a quicklink by clicking on it. Hold <kbd data-variant="small">⌘</kbd> to select multiple. Click the path
-        to edit. Click <strong>Add to Raycast v1</strong> to import them directly.
+        to edit. Click <strong>Add to Raycast</strong> to import them directly.
       </p>
 
       <Button variant="primary" disabled>
-        Add to Raycast v1
+        Add to Raycast
       </Button>
     </div>
   );

--- a/app/(navigation)/quicklinks/shared/shared.tsx
+++ b/app/(navigation)/quicklinks/shared/shared.tsx
@@ -21,7 +21,7 @@ import { Kbd, Kbds } from "@/components/kbd";
 import { QuicklinkComponent } from "../components/quicklink";
 import { toast } from "@/components/toast";
 import { shortenUrl } from "@/utils/common";
-import { getRaycastFlavor, type RaycastImportVersion, useRaycastImportVersion } from "@/app/RaycastFlavor";
+import { getRaycastFlavor } from "@/app/RaycastFlavor";
 
 function withRaycastProtocol(link: string, protocol: string) {
   if (!protocol) return link;
@@ -46,15 +46,14 @@ export function Shared({ quicklinks }: { quicklinks: Quicklink[] }) {
   );
 
   const [raycastProtocol, setRaycastProtocol] = React.useState("");
-  const [raycastImportVersion, setRaycastImportVersion] = useRaycastImportVersion();
 
   React.useEffect(() => {
     async function fetchRaycastProtocol() {
-      const protocol = await getRaycastFlavor(raycastImportVersion);
+      const protocol = await getRaycastFlavor();
       setRaycastProtocol(protocol);
     }
     fetchRaycastProtocol();
-  }, [raycastImportVersion]);
+  }, []);
 
   const [categories, setCategories] = React.useState(initialCategories);
   const categoriesWithRaycastProtocol = React.useMemo(() => {
@@ -160,16 +159,9 @@ export function Shared({ quicklinks }: { quicklinks: Quicklink[] }) {
     );
   }, [selectedQuicklinks]);
 
-  const handleAddToRaycast = React.useCallback(
-    (importVersion: RaycastImportVersion = raycastImportVersion) => {
-      if (!isTouch) {
-        setRaycastImportVersion(importVersion);
-      }
-
-      return addToRaycast(router, selectedQuicklinks, isTouch, importVersion);
-    },
-    [router, selectedQuicklinks, isTouch, raycastImportVersion, setRaycastImportVersion],
-  );
+  const handleAddToRaycast = React.useCallback(() => {
+    return addToRaycast(router, selectedQuicklinks, isTouch);
+  }, [router, selectedQuicklinks, isTouch]);
 
   React.useEffect(() => {
     const down = (event: KeyboardEvent) => {
@@ -223,7 +215,7 @@ export function Shared({ quicklinks }: { quicklinks: Quicklink[] }) {
           <InfoDialog />
           <ButtonGroup>
             <Button variant="primary" disabled={selectedQuicklinks.length === 0} onClick={() => handleAddToRaycast()}>
-              <PlusCircleIcon /> Add to Raycast {raycastImportVersion}
+              <PlusCircleIcon /> Add to Raycast
             </Button>
 
             <DropdownMenu open={actionsOpen} onOpenChange={setActionsOpen}>
@@ -233,22 +225,6 @@ export function Shared({ quicklinks }: { quicklinks: Quicklink[] }) {
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end">
-                {raycastImportVersion === "v1" && (
-                  <DropdownMenuItem
-                    disabled={selectedQuicklinks.length === 0}
-                    onSelect={() => handleAddToRaycast("v2")}
-                  >
-                    <PlusCircleIcon /> Add to Raycast v2
-                  </DropdownMenuItem>
-                )}
-                {raycastImportVersion === "v2" && (
-                  <DropdownMenuItem
-                    disabled={selectedQuicklinks.length === 0}
-                    onSelect={() => handleAddToRaycast("v1")}
-                  >
-                    <PlusCircleIcon /> Add to Raycast v1
-                  </DropdownMenuItem>
-                )}
                 <DropdownMenuItem disabled={selectedQuicklinks.length === 0} onSelect={() => handleDownload()}>
                   <DownloadIcon /> Download JSON
                   <Kbds>

--- a/app/(navigation)/quicklinks/utils/actions.ts
+++ b/app/(navigation)/quicklinks/utils/actions.ts
@@ -2,16 +2,11 @@ import copy from "copy-to-clipboard";
 import { Quicklink } from "../quicklinks";
 import { AppRouterInstance } from "next/dist/shared/lib/app-router-context.shared-runtime";
 import { BASE_URL } from "@/utils/common";
-import {
-  getRaycastFlavor,
-  getIsWindows,
-  setRaycastImportVersion,
-  type RaycastImportVersion,
-} from "@/app/RaycastFlavor";
+import { getRaycastFlavor, getIsRaycastV2 } from "@/app/RaycastFlavor";
 
-function getRaycastIconName(iconName?: string, isWindows?: boolean) {
+function getRaycastIconName(iconName?: string, isRaycastV2?: boolean) {
   if (iconName) {
-    return isWindows ? iconName : `${iconName}-16`;
+    return isRaycastV2 ? iconName : `${iconName}-16`;
   }
   return undefined;
 }
@@ -79,27 +74,18 @@ export function copyUrl(quicklinks: Quicklink[]) {
   copy(makeUrl(quicklinks));
 }
 
-export async function addToRaycast(
-  router: AppRouterInstance,
-  quicklinks: Quicklink[],
-  isTouch?: boolean,
-  importVersion?: RaycastImportVersion,
-) {
+export async function addToRaycast(router: AppRouterInstance, quicklinks: Quicklink[], isTouch?: boolean) {
   // For mobile, always use the standard 'raycast' scheme since iOS apps
   // are typically registered for 'raycast://' not 'raycastinternal://'
   if (isTouch) {
     const quicklinksForImport = withRaycastProtocol(quicklinks, "raycast");
     window.location.href = `raycast://quicklinks/import?${makeQueryString(quicklinksForImport, true)}`;
   } else {
-    if (importVersion) {
-      setRaycastImportVersion(importVersion);
-    }
-
-    const raycastProtocol = await getRaycastFlavor(importVersion);
-    const isWindows = await getIsWindows(importVersion);
+    const raycastProtocol = await getRaycastFlavor();
+    const isRaycastV2 = await getIsRaycastV2();
     const quicklinksForImport = withRaycastProtocol(quicklinks, raycastProtocol);
 
-    if (isWindows) {
+    if (isRaycastV2) {
       const context = encodeURIComponent(
         JSON.stringify(
           quicklinksForImport.map(({ name, link, openWith, icon }) => ({
@@ -117,28 +103,20 @@ export async function addToRaycast(
   }
 }
 
-export async function addQuicklinkToRaycast(
-  router: AppRouterInstance,
-  quicklink: Quicklink,
-  importVersion?: RaycastImportVersion,
-) {
-  if (importVersion) {
-    setRaycastImportVersion(importVersion);
-  }
-
-  const raycastProtocol = await getRaycastFlavor(importVersion);
-  const isWindows = await getIsWindows(importVersion);
+export async function addQuicklinkToRaycast(router: AppRouterInstance, quicklink: Quicklink) {
+  const raycastProtocol = await getRaycastFlavor();
+  const isRaycastV2 = await getIsRaycastV2();
   const [{ name, link, openWith, icon }] = withRaycastProtocol([quicklink], raycastProtocol);
   const encodedQuicklink = encodeURIComponent(
     JSON.stringify({
       name,
       link,
       openWith,
-      icon: getRaycastIconName(icon?.name, isWindows),
+      icon: getRaycastIconName(icon?.name, isRaycastV2),
     }),
   );
 
-  if (isWindows) {
+  if (isRaycastV2) {
     router.replace(`${raycastProtocol}://extensions/raycast/quicklinks/create-quicklink?context=${encodedQuicklink}`);
   } else {
     router.replace(`${raycastProtocol}://extensions/raycast/raycast/create-quicklink?context=${encodedQuicklink}`);

--- a/app/(navigation)/snippets/[[...slug]]/snippets.tsx
+++ b/app/(navigation)/snippets/[[...slug]]/snippets.tsx
@@ -40,12 +40,7 @@ import { Dialog, DialogContent, DialogDescription, DialogTitle, DialogTrigger } 
 import { ButtonGroup } from "@/components/button-group";
 import { InfoDialog } from "../components/InfoDialog";
 import { Kbd, Kbds } from "@/components/kbd";
-import {
-  getRaycastFlavor,
-  getIsWindows,
-  type RaycastImportVersion,
-  useRaycastImportVersion,
-} from "@/app/RaycastFlavor";
+import { getRaycastFlavor, getIsRaycastV2 } from "@/app/RaycastFlavor";
 
 const modifiers = ["!", ":", "_", "__", "-", "@", "@@", "$", ";", ";;", "/", "//", "#", "none"] as const;
 
@@ -90,7 +85,6 @@ export default function Snippets() {
   const [settingsOpen, setSettingsOpen] = React.useState(false);
   const [aboutOpen, setAboutOpen] = React.useState(false);
   const [isTouch, setIsTouch] = React.useState<boolean>();
-  const [raycastImportVersion, setRaycastImportVersion] = useRaycastImportVersion();
 
   const onStart = ({ event, selection }: SelectionEvent) => {
     if (!isTouch && !event?.ctrlKey && !event?.metaKey) {
@@ -197,51 +191,37 @@ export default function Snippets() {
     setToastMessage("Copied URL to clipboard!");
   }, [makeQueryString]);
 
-  const handleAddToRaycast = React.useCallback(
-    async (importVersion: RaycastImportVersion = raycastImportVersion) => {
-      const queryString = makeQueryString();
+  const handleAddToRaycast = React.useCallback(async () => {
+    const queryString = makeQueryString();
 
-      // For mobile, always use the standard 'raycast' scheme since iOS apps
-      // are typically registered for 'raycast://' not 'raycastinternal://'
-      if (isTouch) {
-        window.location.href = `raycast://snippets/import?${queryString}`;
+    // For mobile, always use the standard 'raycast' scheme since iOS apps
+    // are typically registered for 'raycast://' not 'raycastinternal://'
+    if (isTouch) {
+      window.location.href = `raycast://snippets/import?${queryString}`;
+    } else {
+      const raycastProtocol = await getRaycastFlavor();
+      const isRaycastV2 = await getIsRaycastV2();
+
+      if (isRaycastV2) {
+        const snippetsData = selectedSnippets.map((snippet) => {
+          const { name, text, type } = snippet;
+          const keyword =
+            snippet.type === "spelling"
+              ? snippet.keyword
+              : addModifiersToKeyword({
+                  keyword: snippet.keyword,
+                  start: startMod,
+                  end: endMod,
+                });
+          return { name, text, keyword, type };
+        });
+        const context = encodeURIComponent(JSON.stringify(snippetsData));
+        router.replace(`${raycastProtocol}://extensions/raycast/snippets/import-snippets?context=${context}`);
       } else {
-        setRaycastImportVersion(importVersion);
-
-        const raycastProtocol = await getRaycastFlavor(importVersion);
-        const isWindows = await getIsWindows(importVersion);
-
-        if (isWindows) {
-          const snippetsData = selectedSnippets.map((snippet) => {
-            const { name, text, type } = snippet;
-            const keyword =
-              snippet.type === "spelling"
-                ? snippet.keyword
-                : addModifiersToKeyword({
-                    keyword: snippet.keyword,
-                    start: startMod,
-                    end: endMod,
-                  });
-            return { name, text, keyword, type };
-          });
-          const context = encodeURIComponent(JSON.stringify(snippetsData));
-          router.replace(`${raycastProtocol}://extensions/raycast/snippets/import-snippets?context=${context}`);
-        } else {
-          router.replace(`${raycastProtocol}://snippets/import?${makeQueryString()}`);
-        }
+        router.replace(`${raycastProtocol}://snippets/import?${makeQueryString()}`);
       }
-    },
-    [
-      router,
-      makeQueryString,
-      selectedSnippets,
-      startMod,
-      endMod,
-      isTouch,
-      raycastImportVersion,
-      setRaycastImportVersion,
-    ],
-  );
+    }
+  }, [router, makeQueryString, selectedSnippets, startMod, endMod, isTouch]);
 
   React.useEffect(() => {
     setIsTouch(isTouchDevice());
@@ -379,7 +359,7 @@ export default function Snippets() {
               </Dialog>
               <ButtonGroup>
                 <Button variant="primary" disabled={selectedSnippets.length === 0} onClick={() => handleAddToRaycast()}>
-                  <PlusCircleIcon /> Add to Raycast {raycastImportVersion}
+                  <PlusCircleIcon /> Add to Raycast
                 </Button>
 
                 <DropdownMenu open={actionsOpen} onOpenChange={setActionsOpen}>
@@ -389,22 +369,6 @@ export default function Snippets() {
                     </Button>
                   </DropdownMenuTrigger>
                   <DropdownMenuContent align="end">
-                    {raycastImportVersion === "v1" && (
-                      <DropdownMenuItem
-                        disabled={selectedSnippets.length === 0}
-                        onSelect={() => handleAddToRaycast("v2")}
-                      >
-                        <PlusCircleIcon /> Add to Raycast v2
-                      </DropdownMenuItem>
-                    )}
-                    {raycastImportVersion === "v2" && (
-                      <DropdownMenuItem
-                        disabled={selectedSnippets.length === 0}
-                        onSelect={() => handleAddToRaycast("v1")}
-                      >
-                        <PlusCircleIcon /> Add to Raycast v1
-                      </DropdownMenuItem>
-                    )}
                     <DropdownMenuItem disabled={selectedSnippets.length === 0} onSelect={() => handleDownload()}>
                       <DownloadIcon /> Download JSON
                       <Kbds>
@@ -494,7 +458,7 @@ export default function Snippets() {
 
                     <div className={styles.summaryControls}>
                       <Button onClick={() => handleAddToRaycast()} variant="primary">
-                        Add to Raycast {raycastImportVersion}
+                        Add to Raycast
                       </Button>
 
                       <Button onClick={() => setSelectedSnippets([])}>Clear selected</Button>

--- a/app/(navigation)/snippets/components/Instructions.tsx
+++ b/app/(navigation)/snippets/components/Instructions.tsx
@@ -15,11 +15,11 @@ export function Instructions() {
       <h3 className={styles.title}>Install Snippets</h3>
       <p className={styles.description}>
         Select a Snippet by clicking on it. Hold <kbd data-variant="small">⌘</kbd> to select multiple. Click{" "}
-        <strong>Add to Raycast v1</strong> to import them directly.
+        <strong>Add to Raycast</strong> to import them directly.
       </p>
 
       <Button variant="primary" disabled>
-        Add to Raycast v1
+        Add to Raycast
       </Button>
     </div>
   );

--- a/app/(navigation)/snippets/shared/shared.tsx
+++ b/app/(navigation)/snippets/shared/shared.tsx
@@ -10,12 +10,7 @@ import { Toast, ToastTitle } from "../components/Toast";
 import { ScrollArea } from "@/components/scroll-area";
 import { Button } from "@/components/button";
 import { isTouchDevice } from "../utils/isTouchDevice";
-import {
-  getRaycastFlavor,
-  getIsWindows,
-  type RaycastImportVersion,
-  useRaycastImportVersion,
-} from "@/app/RaycastFlavor";
+import { getRaycastFlavor, getIsRaycastV2 } from "@/app/RaycastFlavor";
 import styles from "../[[...slug]]/snippets.module.css";
 import { ChevronDownIcon, CopyClipboardIcon, DownloadIcon, PlusCircleIcon } from "@raycast/icons";
 import { extractSnippets } from "../utils/extractSnippets";
@@ -33,7 +28,6 @@ export function Shared({ snippets }: { snippets: Snippet[] }) {
 
   const [selectedSnippets, setSelectedSnippets] = React.useState([...snippets]);
   const isTouch = React.useMemo(() => (typeof window !== "undefined" ? isTouchDevice() : false), []);
-  const [raycastImportVersion, setRaycastImportVersion] = useRaycastImportVersion();
 
   let gridCols = 1;
   switch (snippets.length) {
@@ -126,11 +120,31 @@ export function Shared({ snippets }: { snippets: Snippet[] }) {
     setCopied(true);
   }, [makeSnippetImportData]);
 
-  const handleAddToRaycast = React.useCallback(
-    async (importVersion: RaycastImportVersion = raycastImportVersion) => {
-      // For mobile, always use the standard 'raycast' scheme since iOS apps
-      // are typically registered for 'raycast://' not 'raycastinternal://'
-      if (isTouch) {
+  const handleAddToRaycast = React.useCallback(async () => {
+    // For mobile, always use the standard 'raycast' scheme since iOS apps
+    // are typically registered for 'raycast://' not 'raycastinternal://'
+    if (isTouch) {
+      const queryString = selectedSnippets
+        .map((snippet) => {
+          const { name, text, type } = snippet;
+          const keyword = snippet.keyword;
+          return `snippet=${encodeURIComponent(JSON.stringify({ name, text, keyword, type }))}`;
+        })
+        .join("&");
+      const url = `raycast://snippets/import?${queryString}`;
+      window.location.href = url;
+    } else {
+      const raycastProtocol = await getRaycastFlavor();
+      const isRaycastV2 = await getIsRaycastV2();
+
+      if (isRaycastV2) {
+        const snippetsData = selectedSnippets.map((snippet) => {
+          const { name, text, keyword, type } = snippet;
+          return { name, text, keyword, type };
+        });
+        const context = encodeURIComponent(JSON.stringify(snippetsData));
+        router.replace(`${raycastProtocol}://extensions/raycast/snippets/import-snippets?context=${context}`);
+      } else {
         const queryString = selectedSnippets
           .map((snippet) => {
             const { name, text, type } = snippet;
@@ -138,35 +152,10 @@ export function Shared({ snippets }: { snippets: Snippet[] }) {
             return `snippet=${encodeURIComponent(JSON.stringify({ name, text, keyword, type }))}`;
           })
           .join("&");
-        const url = `raycast://snippets/import?${queryString}`;
-        window.location.href = url;
-      } else {
-        setRaycastImportVersion(importVersion);
-
-        const raycastProtocol = await getRaycastFlavor(importVersion);
-        const isWindows = await getIsWindows(importVersion);
-
-        if (isWindows) {
-          const snippetsData = selectedSnippets.map((snippet) => {
-            const { name, text, keyword, type } = snippet;
-            return { name, text, keyword, type };
-          });
-          const context = encodeURIComponent(JSON.stringify(snippetsData));
-          router.replace(`${raycastProtocol}://extensions/raycast/snippets/import-snippets?context=${context}`);
-        } else {
-          const queryString = selectedSnippets
-            .map((snippet) => {
-              const { name, text, type } = snippet;
-              const keyword = snippet.keyword;
-              return `snippet=${encodeURIComponent(JSON.stringify({ name, text, keyword, type }))}`;
-            })
-            .join("&");
-          router.replace(`${raycastProtocol}://snippets/import?${queryString}`);
-        }
+        router.replace(`${raycastProtocol}://snippets/import?${queryString}`);
       }
-    },
-    [router, selectedSnippets, isTouch, raycastImportVersion, setRaycastImportVersion],
-  );
+    }
+  }, [router, selectedSnippets, isTouch]);
 
   React.useEffect(() => {
     const down = (event: KeyboardEvent) => {
@@ -229,7 +218,7 @@ export function Shared({ snippets }: { snippets: Snippet[] }) {
             <InfoDialog />
             <ButtonGroup>
               <Button variant="primary" disabled={selectedSnippets.length === 0} onClick={() => handleAddToRaycast()}>
-                <PlusCircleIcon /> Add to Raycast {raycastImportVersion}
+                <PlusCircleIcon /> Add to Raycast
               </Button>
 
               <DropdownMenu open={actionsOpen} onOpenChange={setActionsOpen}>
@@ -239,22 +228,6 @@ export function Shared({ snippets }: { snippets: Snippet[] }) {
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent>
-                  {raycastImportVersion === "v1" && (
-                    <DropdownMenuItem
-                      disabled={selectedSnippets.length === 0}
-                      onSelect={() => handleAddToRaycast("v2")}
-                    >
-                      <PlusCircleIcon /> Add to Raycast v2
-                    </DropdownMenuItem>
-                  )}
-                  {raycastImportVersion === "v2" && (
-                    <DropdownMenuItem
-                      disabled={selectedSnippets.length === 0}
-                      onSelect={() => handleAddToRaycast("v1")}
-                    >
-                      <PlusCircleIcon /> Add to Raycast v1
-                    </DropdownMenuItem>
-                  )}
                   <DropdownMenuItem disabled={selectedSnippets.length === 0} onSelect={() => handleDownload()}>
                     <DownloadIcon /> Download JSON
                     <Kbds>

--- a/app/(navigation)/themes/components/add-to-raycast.tsx
+++ b/app/(navigation)/themes/components/add-to-raycast.tsx
@@ -6,12 +6,10 @@ import { ChevronDownIcon, PlusCircleIcon } from "@raycast/icons";
 import { useRaycastTheme } from "@themes/components/raycast-theme-provider";
 import { isTouchDevice } from "@themes/lib/isTouchDevice";
 import { makeRaycastImportUrl } from "@themes/lib/url";
-import { type RaycastImportVersion, useRaycastImportVersion } from "@/app/RaycastFlavor";
 
 export function AddToRaycast() {
   const [isTouch, setIsTouch] = React.useState<boolean | null>(null);
   const [showActions, setShowActions] = React.useState(false);
-  const [raycastImportVersion, setRaycastImportVersion] = useRaycastImportVersion();
   const { activeTheme } = useRaycastTheme();
 
   const handleCopyTheme = React.useCallback(() => {
@@ -53,17 +51,13 @@ export function AddToRaycast() {
     link.click();
   }, [activeTheme]);
 
-  const handleAddToRaycast = React.useCallback(
-    async (importVersion: RaycastImportVersion = raycastImportVersion) => {
-      if (!activeTheme) return;
+  const handleAddToRaycast = React.useCallback(async () => {
+    if (!activeTheme) return;
 
-      setRaycastImportVersion(importVersion);
-      console.log("Opening theme in Raycast from button");
-      const importUrl = await makeRaycastImportUrl(activeTheme, importVersion);
-      window.open(importUrl);
-    },
-    [activeTheme, raycastImportVersion, setRaycastImportVersion],
-  );
+    console.log("Opening theme in Raycast from button");
+    const importUrl = await makeRaycastImportUrl(activeTheme);
+    window.open(importUrl);
+  }, [activeTheme]);
 
   React.useEffect(() => {
     setIsTouch(isTouchDevice());
@@ -105,7 +99,7 @@ export function AddToRaycast() {
   return !isTouch ? (
     <span className="inline-flex items-center text-sm font-medium shadow-[0px_0px_29px_10px_rgba(0,0,0,0.03)] dark:shadow-[0px_0px_29px_10px_rgba(255,255,255,.06)] rounded-md">
       <Button className="flex-1 rounded-tl-md rounded-bl-md" onClick={() => handleAddToRaycast()}>
-        <PlusCircleIcon /> Add to Raycast {raycastImportVersion}
+        <PlusCircleIcon /> Add to Raycast
       </Button>
 
       <DropdownMenu.Root open={showActions} onOpenChange={setShowActions}>
@@ -126,20 +120,6 @@ export function AddToRaycast() {
             dark:shadow-[0px_0px_0px_1px_rgba(255,255,255,0.2),0px_10px_38px_-10px_rgba(22,23,24,0.35),_0px_10px_20px_-15px_rgba(22,23,24,0.2)]
             `}
           >
-            {raycastImportVersion === "v1" && (
-              <Item onSelect={() => handleAddToRaycast("v2")}>
-                <span className="inline-flex items-center gap-2">
-                  <PlusCircleIcon /> Add to Raycast v2
-                </span>
-              </Item>
-            )}
-            {raycastImportVersion === "v2" && (
-              <Item onSelect={() => handleAddToRaycast("v1")}>
-                <span className="inline-flex items-center gap-2">
-                  <PlusCircleIcon /> Add to Raycast v1
-                </span>
-              </Item>
-            )}
             <Item onSelect={() => handleDownload()}>
               Download JSON
               <Shortcut keys={["⌘", "D"]} />

--- a/app/(navigation)/themes/lib/url.ts
+++ b/app/(navigation)/themes/lib/url.ts
@@ -1,14 +1,10 @@
-import { getRaycastFlavor, setRaycastImportVersion, type RaycastImportVersion } from "@/app/RaycastFlavor";
+import { getRaycastFlavor } from "@/app/RaycastFlavor";
 import { Theme } from "@themes/lib/theme";
 
-export async function makeRaycastImportUrl(theme: Theme, importVersion?: RaycastImportVersion) {
+export async function makeRaycastImportUrl(theme: Theme) {
   const { slug, colors, ...restTheme } = theme;
 
-  if (importVersion) {
-    setRaycastImportVersion(importVersion);
-  }
-
-  const raycastProtocol = await getRaycastFlavor(importVersion);
+  const raycastProtocol = await getRaycastFlavor();
   const url = new URL(`${raycastProtocol}://theme`);
 
   const encodedParams = Object.entries(restTheme).map(

--- a/app/RaycastFlavor.tsx
+++ b/app/RaycastFlavor.tsx
@@ -1,9 +1,5 @@
 "use client";
 
-import React from "react";
-
-export type RaycastImportVersion = "v1" | "v2";
-
 type Flavor =
   | "raycast"
   | "raycastinternal"
@@ -13,8 +9,6 @@ type Flavor =
   | "raycast-x-development";
 type WebsocketFlavor = Exclude<Flavor, "raycast-x">;
 
-const RAYCAST_IMPORT_VERSION_STORAGE_KEY = "raycastImportVersion";
-
 const FLAVOR_PORTS: Record<WebsocketFlavor, number> = {
   "raycast-x-development": 7261,
   "raycast-x-internal": 7262,
@@ -22,6 +16,9 @@ const FLAVOR_PORTS: Record<WebsocketFlavor, number> = {
   raycastinternal: 7264,
   raycast: 7265,
 };
+
+// When classic Raycast already holds port 7265, production Raycast v2 falls back to 7266
+const PRODUCTION_V2_FALLBACK_PORT = 7266;
 
 async function isWebsocketOpen(port: number): Promise<boolean> {
   return new Promise((resolve) => {
@@ -43,126 +40,109 @@ async function supportsWhoami(port: number): Promise<boolean> {
   return new Promise((resolve) => {
     try {
       const socket = new WebSocket(`ws://localhost:${port}`);
+      // Safety net for a non-Raycast process on the port that accepts
+      // the connection but never replies;
+      const timeout = setTimeout(() => {
+        resolve(false);
+        socket.close();
+      }, 1500);
 
       socket.onopen = () => {
         socket.send(JSON.stringify({ method: "whoami", id: "1" }));
       };
 
       socket.onmessage = (event) => {
-        const response = JSON.parse(event.data);
-        resolve(!response.error);
+        clearTimeout(timeout);
+        try {
+          const response = JSON.parse(event.data);
+          resolve(!response.error);
+        } catch {
+          resolve(false);
+        }
         socket.close();
       };
 
-      socket.onerror = () => resolve(false);
+      socket.onerror = () => {
+        clearTimeout(timeout);
+        resolve(false);
+      };
     } catch {
       resolve(false);
     }
   });
 }
 
-const cachedFlavor: Partial<Record<RaycastImportVersion, Flavor>> = {};
-const cachedIsWindows: Partial<Record<RaycastImportVersion, boolean>> = {};
+type Detection = { flavor: Flavor; isRaycastV2: boolean };
 
-function normalizeRaycastImportVersion(version: string | null): RaycastImportVersion {
-  return version === "v2" ? "v2" : "v1";
+let cachedDetection: Detection | undefined;
+
+// Production Raycast v2 registers 'raycast' on Windows and 'raycast-x' on macOS
+function productionV2Flavor(): Flavor {
+  const isWindowsPlatform = typeof navigator !== "undefined" && navigator.userAgent.includes("Windows");
+  return isWindowsPlatform ? "raycast" : "raycast-x";
 }
 
-export function getRaycastImportVersion(): RaycastImportVersion {
-  if (typeof window === "undefined") {
-    return "v1";
-  }
-
-  try {
-    return normalizeRaycastImportVersion(localStorage.getItem(RAYCAST_IMPORT_VERSION_STORAGE_KEY));
-  } catch (error) {
-    return "v1";
-  }
+// Resolves true as soon as any probe succeeds, without waiting for the slower ones
+async function anyResolvesTrue(probes: Promise<boolean>[]): Promise<boolean> {
+  return new Promise((resolve) => {
+    let pending = probes.length;
+    probes.forEach((probe) =>
+      probe.then((result) => {
+        if (result) {
+          resolve(true);
+        } else if (--pending === 0) {
+          resolve(false);
+        }
+      }),
+    );
+  });
 }
 
-export function setRaycastImportVersion(version: RaycastImportVersion) {
-  if (typeof window === "undefined") {
-    return;
+async function detectRaycast(): Promise<Detection> {
+  if (cachedDetection) {
+    return cachedDetection;
   }
 
-  try {
-    localStorage.setItem(RAYCAST_IMPORT_VERSION_STORAGE_KEY, version);
-  } catch (error) {
-    console.log("Could not set Raycast import version in localStorage", error);
-  }
-}
+  // Start all probes upfront so detection takes as long as the slowest needed one, not the sum
+  const xDevOpen = isWebsocketOpen(FLAVOR_PORTS["raycast-x-development"]);
+  const xInternalOpen = isWebsocketOpen(FLAVOR_PORTS["raycast-x-internal"]);
+  // Production v2 and classic macOS share port 7265: v2 answers whoami successfully,
+  // classic rejects it with a method-not-found error. When classic holds 7265,
+  // v2 sits on the fallback port, so race both.
+  const productionV2Detected = anyResolvesTrue([
+    supportsWhoami(FLAVOR_PORTS.raycast),
+    supportsWhoami(PRODUCTION_V2_FALLBACK_PORT),
+  ]);
+  const classicDebugOpen = isWebsocketOpen(FLAVOR_PORTS.raycastdebug);
+  const classicInternalOpen = isWebsocketOpen(FLAVOR_PORTS.raycastinternal);
 
-export function useRaycastImportVersion() {
-  const [version, setVersionState] = React.useState<RaycastImportVersion>("v1");
+  let detection: Detection;
 
-  React.useEffect(() => {
-    setVersionState(getRaycastImportVersion());
-  }, []);
-
-  const updateVersion = React.useCallback((version: RaycastImportVersion) => {
-    setRaycastImportVersion(version);
-    setVersionState(version);
-  }, []);
-
-  return [version, updateVersion] as const;
-}
-
-export async function getRaycastFlavor(version = getRaycastImportVersion()): Promise<Flavor> {
-  const cachedVersionFlavor = cachedFlavor[version];
-  if (cachedVersionFlavor) {
-    return cachedVersionFlavor;
-  }
-
-  if (version === "v2") {
-    let flavor: Flavor;
-
-    if (await isWebsocketOpen(FLAVOR_PORTS["raycast-x-development"])) {
-      flavor = "raycast-x-development";
-    } else if (await isWebsocketOpen(FLAVOR_PORTS["raycast-x-internal"])) {
-      flavor = "raycast-x-internal";
-    } else {
-      flavor = "raycast-x";
-    }
-
-    cachedFlavor.v2 = flavor;
-    return flavor;
-  }
-
-  let flavor: Flavor;
-
-  if (await isWebsocketOpen(FLAVOR_PORTS.raycastdebug)) {
-    flavor = "raycastdebug";
-  } else if (await isWebsocketOpen(FLAVOR_PORTS.raycastinternal)) {
-    flavor = "raycastinternal";
+  // Raycast v2 takes priority over classic when both are installed
+  if (await xDevOpen) {
+    detection = { flavor: "raycast-x-development", isRaycastV2: true };
+  } else if (await xInternalOpen) {
+    detection = { flavor: "raycast-x-internal", isRaycastV2: true };
+  } else if (await productionV2Detected) {
+    detection = { flavor: productionV2Flavor(), isRaycastV2: true };
+  } else if (await classicDebugOpen) {
+    detection = { flavor: "raycastdebug", isRaycastV2: false };
+  } else if (await classicInternalOpen) {
+    detection = { flavor: "raycastinternal", isRaycastV2: false };
   } else {
-    flavor = "raycast";
+    detection = { flavor: "raycast", isRaycastV2: false };
   }
 
-  cachedFlavor.v1 = flavor;
+  cachedDetection = detection;
+  return detection;
+}
+
+export async function getRaycastFlavor(): Promise<Flavor> {
+  const { flavor } = await detectRaycast();
   return flavor;
 }
 
-export async function getIsWindows(version = getRaycastImportVersion()): Promise<boolean> {
-  const cachedVersionIsWindows = cachedIsWindows[version];
-  if (cachedVersionIsWindows !== undefined) {
-    return cachedVersionIsWindows;
-  }
-
-  const flavor = await getRaycastFlavor(version);
-
-  if (flavor === "raycast-x" || flavor === "raycast-x-development" || flavor === "raycast-x-internal") {
-    cachedIsWindows[version] = true;
-    return true;
-  }
-
-  // macOS and Windows versions share the 'raycast' flavor, so we check whoami support to determine if it's Windows
-  // Windows supports whoami, macOS does not
-  if (flavor === "raycast") {
-    const isWindows = await supportsWhoami(FLAVOR_PORTS.raycast);
-    cachedIsWindows[version] = isWindows;
-    return isWindows;
-  }
-
-  cachedIsWindows[version] = false;
-  return false;
+export async function getIsRaycastV2(): Promise<boolean> {
+  const { isRaycastV2 } = await detectRaycast();
+  return isRaycastV2;
 }


### PR DESCRIPTION
Fixes [XRAY-5401](https://linear.app/raycast/issue/XRAY-5401/import-snippet-flow-is-incorrect-for-snippets-explorer)

## Root cause

On macOS with Raycast v2 (X-Ray) running, "Add to Raycast" on the snippets explorer misdetected the setup as **Windows**: production v2 answers the `whoami` probe on port 7265 (the port it shares with classic for backward compatibility). ray.so then sent the extension-style deeplink on the plain `raycast://` scheme — which macOS routes by app registration, not by what's running. Classic Raycast owns `raycast://`, received the deeplink, and its Import Snippets command drops the `context` param entirely (`SnippetsImportCommand` only implements the parameterless primary action), landing users on the "Import Snippets" / **"Select File"** view.

## Changes

- **Rename `getIsWindows` → `getIsRaycastV2`** — that's what the `whoami` probe actually detects (at the time, v2 was Windows-only).
- **Detection prioritizes Raycast v2** when both apps are present: x-dev (7261) → x-internal (7262) → production `whoami` raced on 7265 **and 7266** (v2 falls back to 7266 when classic holds 7265) → classic flavors. All probes start in parallel; only v2 answers `whoami` successfully (classic rejects it with method-not-found), so the shared port is unambiguous. Result cached per page load.
- **Per-OS production scheme**: `raycast-x://` on macOS, `raycast://` on Windows — matching what each production build actually registers, so the deeplink always reaches the app that was detected.
- **Classic fallback format**: when v2 isn't detected, send the classic-format link (e.g. `raycast://snippets/import?snippet=…`), which classic imports natively — and v2 also handles via its legacy route if it happens to own the scheme.
- **Removed the manual v1/v2 toggle** across snippets, quicklinks, prompts, presets and themes (buttons now just say "Add to Raycast"). Detection is automatic; users who want to import into classic specifically can simply close X-Ray.

## Testing

Drove the real page in headless Chromium, clicking "Add to Raycast" and capturing the produced deeplink, with the WebSocket layer stubbed to simulate each configuration:

| Scenario | Deeplink |
|---|---|
| classic@7265 + x-ray@7266 (the reported bug) | `raycast-x://extensions/raycast/snippets/import-snippets?context=…` ✅ |
| only x-ray production | `raycast-x://extensions/…?context=…` ✅ |
| only classic | `raycast://snippets/import?snippet=…` ✅ |
| nothing running | `raycast://snippets/import?snippet=…` ✅ |
| x-ray internal (7262) | `raycast-x-internal://extensions/…?context=…` ✅ |
| classic internal (7264) | `raycastinternal://snippets/import?snippet=…` ✅ |

Plus an unstubbed run against a real running X-Ray internal build, producing the correct `raycast-x-internal://…?context=[{"name":…,"text":…}]` deeplink (payload validated against v2's import schema).