### PR TITLE
feat: support multiple code blocks with independent syntax highlighting

### DIFF
--- a/app/(navigation)/(code)/components/AddCodeBlockButton.module.css
+++ b/app/(navigation)/(code)/components/AddCodeBlockButton.module.css
@@ -1,0 +1,57 @@
+.addButton {
+  position: absolute;
+  z-index: 1;
+  top: 0%;
+  right: 0;
+  display: inline-flex;
+  width: 32px;
+  height: 32px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background: var(--panel-background);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.45);
+  color: rgba(255, 255, 255, 0.55);
+  cursor: pointer;
+  transform: translate(50%, -50%);
+  transition:
+    color 120ms ease,
+    background 120ms ease,
+    box-shadow 120ms ease;
+}
+
+.addButton::before {
+  position: absolute;
+  padding: 1px;
+  border-radius: inherit;
+  background: linear-gradient(
+    20deg,
+    rgba(255, 255, 255, 0.1) 0%,
+    rgba(255, 255, 255, 0.28) 40%,
+    rgba(255, 255, 255, 0.1) 100%
+  );
+  content: "";
+  inset: 0;
+  -webkit-mask:
+    linear-gradient(#fff 0 0) content-box,
+    linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  pointer-events: none;
+}
+
+.addButton:hover {
+  background: color-mix(in srgb, var(--panel-background) 85%, white 8%);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.55);
+  color: rgba(255, 255, 255, 0.95);
+}
+
+@media (max-width: 767px) {
+  .addButton {
+    top: 12px;
+    right: 12px;
+    transform: none;
+  }
+}

--- a/app/(navigation)/(code)/components/AddCodeBlockButton.tsx
+++ b/app/(navigation)/(code)/components/AddCodeBlockButton.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useAtomValue, useSetAtom } from "jotai";
+import { PlusIcon } from "@raycast/icons";
+
+import { addBlockAtom, blocksAtom, MAX_CODE_BLOCKS } from "../store/blocks";
+import { codeExampleAtom } from "../store/code";
+import { LANGUAGES } from "../util/languages";
+import styles from "./AddCodeBlockButton.module.css";
+
+function AddCodeBlockButton() {
+  const blocks = useAtomValue(blocksAtom);
+  const addBlock = useSetAtom(addBlockAtom);
+  const codeExample = useAtomValue(codeExampleAtom);
+  const atLimit = blocks.length >= MAX_CODE_BLOCKS;
+  const showingExample = blocks.length === 1 && !blocks.some((block) => block.code.length > 0);
+
+  if (atLimit) return null;
+
+  const handleAddBlock = () => {
+    if (showingExample && codeExample) {
+      const detectedLanguageKey = Object.keys(LANGUAGES).find((key) => LANGUAGES[key] === codeExample.language) ?? null;
+      addBlock({
+        code: codeExample.code,
+        languageKey: null,
+        detectedLanguageKey,
+      });
+      return;
+    }
+    addBlock();
+  };
+
+  return (
+    <button
+      type="button"
+      className={styles.addButton}
+      onClick={handleAddBlock}
+      aria-label="Add code block"
+      title="Add code block"
+    >
+      <PlusIcon width={16} height={16} />
+    </button>
+  );
+}
+
+export default AddCodeBlockButton;

--- a/app/(navigation)/(code)/components/CodeBlocks.module.css
+++ b/app/(navigation)/(code)/components/CodeBlocks.module.css
@@ -1,0 +1,45 @@
+.blocks {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.windowWrap {
+  position: relative;
+}
+
+.removeButton {
+  position: absolute;
+  z-index: 2;
+  top: 10px;
+  right: 10px;
+  display: inline-flex;
+  width: 24px;
+  height: 24px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: none;
+  border-radius: 6px;
+  background: rgb(0 0 0 / 0.35);
+  color: rgb(255 255 255 / 0.75);
+  cursor: pointer;
+  opacity: 0;
+  pointer-events: none;
+  transition:
+    opacity 120ms ease,
+    background 120ms ease,
+    color 120ms ease;
+}
+
+.windowWrap:hover .removeButton,
+.windowWrap:focus-within .removeButton {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.removeButton:hover {
+  background: rgb(0 0 0 / 0.55);
+  color: rgb(255 255 255 / 0.95);
+}

--- a/app/(navigation)/(code)/components/CodeBlocks.tsx
+++ b/app/(navigation)/(code)/components/CodeBlocks.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import classNames from "classnames";
+import { ReactNode } from "react";
+import { useAtomValue, useSetAtom } from "jotai";
+import { TrashIcon } from "@raycast/icons";
+
+import { activeBlockIdAtom, blocksAtom, removeBlockAtom, type CodeBlock } from "../store/blocks";
+import Editor from "./Editor";
+import styles from "./CodeBlocks.module.css";
+
+type CodeBlocksProps = {
+  windowClassName?: string;
+  renderChrome?: (block: CodeBlock, index: number) => ReactNode;
+  renderEditor?: (block: CodeBlock, index: number, editor: ReactNode) => ReactNode;
+  renderWindow?: (block: CodeBlock, index: number, editor: ReactNode) => ReactNode;
+};
+
+function CodeBlocks({ windowClassName, renderChrome, renderEditor, renderWindow }: CodeBlocksProps) {
+  const blocks = useAtomValue(blocksAtom);
+  const setActiveBlockId = useSetAtom(activeBlockIdAtom);
+  const removeBlock = useSetAtom(removeBlockAtom);
+
+  return (
+    <div className={styles.blocks}>
+      {blocks.map((block, index) => {
+        const editor = <Editor blockId={block.id} />;
+        const content = renderEditor ? renderEditor(block, index, editor) : editor;
+
+        return (
+          <div
+            key={block.id}
+            className={classNames(styles.windowWrap, !renderWindow && windowClassName)}
+            data-code-window
+            onMouseDown={() => setActiveBlockId(block.id)}
+          >
+            {renderWindow ? (
+              renderWindow(block, index, editor)
+            ) : (
+              <>
+                {renderChrome?.(block, index)}
+                {content}
+              </>
+            )}
+            {blocks.length > 1 ? (
+              <button
+                type="button"
+                className={styles.removeButton}
+                data-ignore-in-export
+                aria-label={`Remove block ${index + 1}`}
+                onClick={(event) => {
+                  event.stopPropagation();
+                  removeBlock(block.id);
+                }}
+              >
+                <TrashIcon width={14} height={14} />
+              </button>
+            ) : null}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+export default CodeBlocks;

--- a/app/(navigation)/(code)/components/Controls.module.css
+++ b/app/(navigation)/(code)/components/Controls.module.css
@@ -1,10 +1,12 @@
-.controls {
+.controlsDock {
   position: fixed;
-
   z-index: 20;
   bottom: -1px;
   left: 0;
+  width: 100%;
+}
 
+.controls {
   display: flex;
   width: 100%;
   align-items: center;
@@ -21,13 +23,11 @@
   @media (min-width: 768px) {
     --radius: 16px;
 
-    left: 50%;
     overflow: initial;
     width: auto;
     border: none;
     border-top-left-radius: var(--radius);
     border-top-right-radius: var(--radius);
-    transform: translateX(-50%);
 
     &::before {
       position: absolute;
@@ -49,5 +49,17 @@
       mask-composite: exclude;
       pointer-events: none;
     }
+  }
+}
+
+@media (min-width: 768px) {
+  .controlsDock {
+    left: 50%;
+    width: auto;
+    transform: translateX(-50%);
+  }
+
+  .controls {
+    position: relative;
   }
 }

--- a/app/(navigation)/(code)/components/Controls.tsx
+++ b/app/(navigation)/(code)/components/Controls.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 
 import styles from "./Controls.module.css";
+import AddCodeBlockButton from "./AddCodeBlockButton";
 import BackgroundControl from "./BackgroundControl";
 import DarkModeControl from "./DarkModeControl";
-import ExportButton from "./ExportButton";
 import LanguageControl from "./LanguageControl";
 import PaddingControl from "./PaddingControl";
 import ThemeControl from "./ThemeControl";
@@ -11,13 +11,16 @@ import LineNumberControl from "./LineNumberControl";
 
 const Controls: React.FC = () => {
   return (
-    <div className={styles.controls}>
-      <ThemeControl />
-      <BackgroundControl />
-      <DarkModeControl />
-      <LineNumberControl />
-      <PaddingControl />
-      <LanguageControl />
+    <div className={styles.controlsDock}>
+      <div className={styles.controls}>
+        <ThemeControl />
+        <BackgroundControl />
+        <DarkModeControl />
+        <LineNumberControl />
+        <PaddingControl />
+        <LanguageControl />
+      </div>
+      <AddCodeBlockButton />
     </div>
   );
 };

--- a/app/(navigation)/(code)/components/Editor.tsx
+++ b/app/(navigation)/(code)/components/Editor.tsx
@@ -6,10 +6,11 @@ import React, {
   FocusEventHandler,
   useState,
   useEffect,
+  useMemo,
 } from "react";
 import styles from "./Editor.module.css";
-import { useAtom, useSetAtom } from "jotai";
-import { codeAtom, isCodeExampleAtom, selectedLanguageAtom } from "../store/code";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
+import { codeExampleAtom, detectBlockLanguage, getBlockLanguage, isCodeExampleAtom } from "../store/code";
 import {
   THEMES,
   themeAtom,
@@ -22,8 +23,15 @@ import useHotkeys from "../../../../utils/useHotkeys";
 import HighlightedCode from "./HighlightedCode";
 import classNames from "classnames";
 import { derivedFlashMessageAtom } from "../store/flash";
-import { highlightedLinesAtom, showLineNumbersAtom } from "../store";
 import { LANGUAGES } from "../util/languages";
+import {
+  activeBlockIdAtom,
+  blocksAtom,
+  createEmptyBlock,
+  resolvedActiveBlockIdAtom,
+  setBlocksAndPersistAtom,
+  updateBlockAtom,
+} from "../store/blocks";
 
 function indentText(text: string) {
   return text
@@ -130,22 +138,41 @@ const fontMap = {
   "google-sans-code": styles.googleSansCode,
 } as const;
 
-function Editor() {
+type EditorProps = {
+  blockId: string;
+};
+
+function Editor({ blockId }: EditorProps) {
   const textareaRef = useRef<HTMLTextAreaElement>(null);
-  const [code, setCode] = useAtom(codeAtom);
-  const [selectedLanguage, setSelectedLanguage] = useAtom(selectedLanguageAtom);
-  const [themeCSS] = useAtom(themeCSSAtom);
+  const blocks = useAtomValue(blocksAtom);
+  const setBlocksAndPersist = useSetAtom(setBlocksAndPersistAtom);
+  const updateBlock = useSetAtom(updateBlockAtom);
+  const setActiveBlockId = useSetAtom(activeBlockIdAtom);
+  const codeExample = useAtomValue(codeExampleAtom);
   const [isCodeExample] = useAtom(isCodeExampleAtom);
+  const [themeCSS] = useAtom(themeCSSAtom);
   const [themeFont] = useAtom(themeFontAtom);
   const [theme, setTheme] = useAtom(themeAtom);
   const [unlockedThemes, setUnlockedThemes] = useAtom(unlockedThemesAtom);
   const setFlashMessage = useSetAtom(derivedFlashMessageAtom);
-  const setHighlightedLines = useSetAtom(highlightedLinesAtom);
   const [isHighlightingLines, setIsHighlightingLines] = useState(false);
   const [showLineNumbers] = useAtom(themeLineNumbersAtom);
+
+  const block = blocks.find((b) => b.id === blockId);
+  const showingExample = blocks.length === 1 && !blocks.some((b) => b.code.length > 0);
+  const code = showingExample && block ? (codeExample?.code ?? "") : (block?.code ?? "");
+  const selectedLanguage = useMemo(() => {
+    if (!block) return null;
+    if (showingExample && codeExample) return codeExample.language;
+    return getBlockLanguage(block);
+  }, [block, showingExample, codeExample]);
+
   const numberOfLines = (code.match(/\n/g) || []).length;
 
+  const isActive = useAtomValue(resolvedActiveBlockIdAtom) === blockId;
+
   useHotkeys("f", (event) => {
+    if (!isActive) return;
     event.preventDefault();
     textareaRef.current?.focus();
   });
@@ -191,34 +218,70 @@ function Editor() {
           icon: React.createElement(THEMES.rabbit.icon || "", { style: { color: "black" } }),
         });
       }
-      setCode(event.target.value);
+
+      const nextCode = event.target.value;
+
+      if (showingExample) {
+        const detectedLanguageKey = codeExample
+          ? (Object.keys(LANGUAGES).find((key) => LANGUAGES[key] === codeExample.language) ?? null)
+          : null;
+        setBlocksAndPersist([
+          createEmptyBlock({
+            id: blockId,
+            code: nextCode,
+            languageKey: null,
+            detectedLanguageKey,
+            title: block?.title ?? "",
+          }),
+        ]);
+      } else {
+        updateBlock({ blockId, update: { code: nextCode } });
+      }
+
+      detectBlockLanguage(nextCode).then((language) => {
+        if (LANGUAGES[language]) {
+          updateBlock({ blockId, update: { detectedLanguageKey: language } });
+        }
+      });
     },
-    [setCode, setTheme, setFlashMessage, setUnlockedThemes, unlockedThemes, theme.id],
+    [
+      block?.title,
+      blockId,
+      codeExample,
+      setBlocksAndPersist,
+      setFlashMessage,
+      setTheme,
+      setUnlockedThemes,
+      showingExample,
+      theme.id,
+      unlockedThemes,
+      updateBlock,
+    ],
   );
 
   const handleFocus = useCallback<FocusEventHandler>(() => {
-    if (isCodeExample && textareaRef.current) {
+    setActiveBlockId(blockId);
+    if (isCodeExample && showingExample && textareaRef.current) {
       // Safari needs a timeout otherwise the selection flickers
       const textarea = textareaRef.current;
       setTimeout(() => {
         textarea.select();
       }, 1);
     }
-  }, [isCodeExample]);
+  }, [blockId, isCodeExample, setActiveBlockId, showingExample]);
 
   useEffect(() => {
     const listener = (event: MouseEvent) => {
       const target = event.target as HTMLElement;
       const lineNumber = (target.closest("[data-line]") as HTMLElement)?.dataset?.line;
+      const editorRoot = textareaRef.current?.closest("[data-block-id]") as HTMLElement | null;
+      if (!editorRoot || !editorRoot.contains(target)) return;
+
       if (lineNumber && isHighlightingLines) {
-        setHighlightedLines((prev) => {
-          const line = Number(lineNumber);
-          if (prev.includes(line)) {
-            return prev.filter((l) => l !== line);
-          } else {
-            return [...prev, line];
-          }
-        });
+        const line = Number(lineNumber);
+        const prev = block?.highlightedLines ?? [];
+        const next = prev.includes(line) ? prev.filter((l) => l !== line) : [...prev, line];
+        updateBlock({ blockId, update: { highlightedLines: next } });
       }
     };
 
@@ -227,7 +290,7 @@ function Editor() {
     return () => {
       document.removeEventListener("click", listener);
     };
-  }, [setHighlightedLines, isHighlightingLines]);
+  }, [block?.highlightedLines, blockId, isHighlightingLines, updateBlock]);
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -251,6 +314,8 @@ function Editor() {
     };
   }, []);
 
+  if (!block) return null;
+
   return (
     <div
       className={classNames(
@@ -265,6 +330,8 @@ function Editor() {
       )}
       style={{ "--editor-padding": "16px", ...themeCSS } as React.CSSProperties}
       data-value={code}
+      data-block-id={blockId}
+      onMouseDown={() => setActiveBlockId(blockId)}
     >
       <textarea
         rows={1}
@@ -281,7 +348,7 @@ function Editor() {
         onFocus={handleFocus}
         data-enable-grammarly="false"
       />
-      <HighlightedCode code={code} selectedLanguage={selectedLanguage} />
+      <HighlightedCode code={code} selectedLanguage={selectedLanguage} highlightedLines={block.highlightedLines} />
     </div>
   );
 }

--- a/app/(navigation)/(code)/components/HighlightedCode.tsx
+++ b/app/(navigation)/(code)/components/HighlightedCode.tsx
@@ -3,20 +3,20 @@ import React, { useEffect, useState } from "react";
 import { Language, LANGUAGES } from "../util/languages";
 
 import styles from "./Editor.module.css";
-import { highlightedLinesAtom, highlighterAtom, loadingLanguageAtom } from "../store";
-import { useAtom, useAtomValue, useSetAtom } from "jotai";
+import { highlighterAtom, loadingLanguageAtom } from "../store";
+import { useAtomValue, useSetAtom } from "jotai";
 import { themeDarkModeAtom, themeAtom } from "../store/themes";
 
 type PropTypes = {
   selectedLanguage: Language | null;
   code: string;
+  highlightedLines?: number[];
 };
 
-const HighlightedCode: React.FC<PropTypes> = ({ selectedLanguage, code }) => {
+const HighlightedCode: React.FC<PropTypes> = ({ selectedLanguage, code, highlightedLines = [] }) => {
   const [highlightedHtml, setHighlightedHtml] = useState("");
   const highlighter = useAtomValue(highlighterAtom);
   const setIsLoadingLanguage = useSetAtom(loadingLanguageAtom);
-  const highlightedLines = useAtomValue(highlightedLinesAtom);
   const darkMode = useAtomValue(themeDarkModeAtom);
   const theme = useAtomValue(themeAtom);
   const themeName = theme.id === "tailwind" ? (darkMode ? "tailwind-dark" : "tailwind-light") : "css-variables";

--- a/app/(navigation)/(code)/components/InfoDialog.tsx
+++ b/app/(navigation)/(code)/components/InfoDialog.tsx
@@ -28,7 +28,7 @@ export function InfoDialog() {
             <p>Code Images by Raycast is a tool to create beautiful screenshots of your code.</p>
             <p>
               Pick a theme from a range of syntax colors and backgrounds, the language of your code and choose between
-              light or dark mode.
+              light or dark mode. You can also stack multiple code blocks with different languages in one image.
             </p>
             <p>
               Customize the padding and when you’re ready, click export image in the top-right corner to save the image

--- a/app/(navigation)/(code)/components/LanguageControl.tsx
+++ b/app/(navigation)/(code)/components/LanguageControl.tsx
@@ -36,7 +36,6 @@ const LanguageControl: React.FC = () => {
   const [selectedLanguage, setSelectedLanguage] = useAtom(selectedLanguageAtom);
   const [autoDetectLanguage] = useAtom(autoDetectLanguageAtom);
   const [isLoadingLanguage] = useAtom(loadingLanguageAtom);
-
   const items: LanguageItem[] = useMemo(() => {
     const languageItems = Object.entries(LANGUAGES).map(([key, lang]) => ({
       id: key,

--- a/app/(navigation)/(code)/components/ResizableFrame.module.css
+++ b/app/(navigation)/(code)/components/ResizableFrame.module.css
@@ -10,7 +10,6 @@
 .windowSizeDragPoint {
   position: absolute;
   z-index: 2;
-  top: 50%;
   width: 24px;
   height: 24px;
   cursor: col-resize;

--- a/app/(navigation)/(code)/components/ResizableFrame.tsx
+++ b/app/(navigation)/(code)/components/ResizableFrame.tsx
@@ -1,6 +1,15 @@
-import React, { MouseEventHandler, PropsWithChildren, useCallback, useRef, useState } from "react";
-import { useAtom } from "jotai";
+import React, {
+  MouseEventHandler,
+  PropsWithChildren,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import { useAtom, useAtomValue } from "jotai";
 import { windowWidthAtom } from "../store";
+import { blocksAtom } from "../store/blocks";
 import classnames from "classnames";
 import { CSSTransition } from "react-transition-group";
 
@@ -10,18 +19,56 @@ import XMarkIcon from "../assets/icons/x-mark-circle-filled-16.svg";
 
 type Handle = "right" | "left";
 
-let maxWidth = 920;
-let minWidth = 520;
+const maxWidth = 920;
+const minWidth = 520;
 
 const ResizableFrame: React.FC<PropsWithChildren> = ({ children }) => {
-  const currentHandleRef = useRef<Handle>(undefined);
+  const currentHandleRef = useRef<Handle | undefined>(undefined);
+  const frameRef = useRef<HTMLDivElement>(null);
   const windowRef = useRef<HTMLDivElement>(null);
-  const startWidthRef = useRef<number>(undefined);
-  const startXRef = useRef<number>(undefined);
+  const startWidthRef = useRef<number | undefined>(undefined);
+  const startXRef = useRef<number | undefined>(undefined);
   const [windowWidth, setWindowWidth] = useAtom(windowWidthAtom);
   const [isResizing, setResizing] = useState(false);
   const resetWindowWidthRef = useRef<HTMLDivElement>(null);
   const rulerRef = useRef<HTMLDivElement>(null);
+  const blocks = useAtomValue(blocksAtom);
+  const [handleTops, setHandleTops] = useState<number[]>([0]);
+
+  const measureHandleTops = useCallback(() => {
+    const frame = frameRef.current;
+    if (!frame) return;
+
+    const windows = frame.querySelectorAll<HTMLElement>("[data-code-window]");
+    const frameTop = frame.getBoundingClientRect().top;
+
+    if (windows.length === 0) {
+      setHandleTops([frame.getBoundingClientRect().height / 2]);
+      return;
+    }
+
+    setHandleTops(
+      Array.from(windows).map((el) => {
+        const rect = el.getBoundingClientRect();
+        return rect.top - frameTop + rect.height / 2;
+      }),
+    );
+  }, []);
+
+  useLayoutEffect(() => {
+    measureHandleTops();
+  }, [measureHandleTops, blocks, windowWidth]);
+
+  useEffect(() => {
+    const frame = frameRef.current;
+    if (!frame) return;
+
+    const observer = new ResizeObserver(() => measureHandleTops());
+    observer.observe(frame);
+    frame.querySelectorAll("[data-code-window]").forEach((el) => observer.observe(el));
+
+    return () => observer.disconnect();
+  }, [measureHandleTops, blocks.length]);
 
   const mouseMoveHandler = useCallback(
     (event: MouseEvent) => {
@@ -77,15 +124,23 @@ const ResizableFrame: React.FC<PropsWithChildren> = ({ children }) => {
   );
 
   return (
-    <div className={classnames(styles.resizableFrame, isResizing && styles.isResizing)}>
-      <div
-        className={classnames(styles.windowSizeDragPoint, styles.left)}
-        onMouseDown={handleResizeFrameX("left")}
-      ></div>
-      <div
-        className={classnames(styles.windowSizeDragPoint, styles.right)}
-        onMouseDown={handleResizeFrameX("right")}
-      ></div>
+    <div ref={frameRef} className={classnames(styles.resizableFrame, isResizing && styles.isResizing)}>
+      {handleTops.map((top, index) => (
+        <React.Fragment key={index}>
+          <div
+            className={classnames(styles.windowSizeDragPoint, styles.left)}
+            style={{ top }}
+            data-ignore-in-export
+            onMouseDown={handleResizeFrameX("left")}
+          />
+          <div
+            className={classnames(styles.windowSizeDragPoint, styles.right)}
+            style={{ top }}
+            data-ignore-in-export
+            onMouseDown={handleResizeFrameX("right")}
+          />
+        </React.Fragment>
+      ))}
       <div ref={windowRef} style={{ width: windowWidth || "auto" }}>
         {children}
       </div>

--- a/app/(navigation)/(code)/components/frames/Auth0Frame.tsx
+++ b/app/(navigation)/(code)/components/frames/Auth0Frame.tsx
@@ -1,12 +1,16 @@
 import classNames from "classnames";
-import { useAtom, useAtomValue } from "jotai";
+import { ReactNode } from "react";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
 
 import { fileNameAtom, showBackgroundAtom, subtitleAtom } from "../../store";
-import { selectedLanguageAtom } from "../../store/code";
+import { updateBlockAtom, type CodeBlock } from "../../store/blocks";
+import { getBlockLanguage, selectedLanguageAtom } from "../../store/code";
 import { paddingAtom } from "../../store/padding";
 import { themeDarkModeAtom } from "../../store/themes";
 import useIsSafari from "../../util/useIsSafari";
+import { useIsMultiBlock, usePrimaryBlockId } from "../../hooks/usePrimaryBlockId";
 
+import CodeBlocks from "../CodeBlocks";
 import Editor from "../Editor";
 import sharedStyles from "./DefaultFrame.module.css";
 import styles from "./Auth0Frame.module.css";
@@ -15,12 +19,45 @@ const Auth0Frame = () => {
   const [padding] = useAtom(paddingAtom);
   const [showBackground] = useAtom(showBackgroundAtom);
   const [fileName, setFileName] = useAtom(fileNameAtom);
-  const [subtitle, setSubtitle] = useAtom(subtitleAtom);
+  const [subtitle] = useAtom(subtitleAtom);
   const darkMode = useAtomValue(themeDarkModeAtom);
   const isSafari = useIsSafari();
   const selectedLanguage = useAtomValue(selectedLanguageAtom);
   const subtitleFallback = selectedLanguage?.name ?? "Plain Text";
   const subtitleDisplayValue = subtitle || subtitleFallback;
+  const isMulti = useIsMultiBlock();
+  const primaryBlockId = usePrimaryBlockId();
+  const updateBlock = useSetAtom(updateBlockAtom);
+
+  const renderWindow = (block: CodeBlock, index: number, editor: ReactNode) => {
+    const languageName = getBlockLanguage(block)?.name ?? "Plain Text";
+    return (
+      <>
+        <div className={styles.toolbar}>
+          <div className={styles.controls}>
+            <span className={styles.control}></span>
+            <span className={styles.control}></span>
+            <span className={styles.control}></span>
+          </div>
+          <div className={styles.badge} data-value={block.title}>
+            <input
+              type="text"
+              value={block.title}
+              onChange={(event) => updateBlock({ blockId: block.id, update: { title: event.target.value } })}
+              spellCheck={false}
+              tabIndex={-1}
+              size={1}
+            />
+            {block.title.length === 0 ? <span data-ignore-in-export>{`Untitled-${index + 1}`}</span> : null}
+          </div>
+          <div className={styles.runtime} data-value={languageName}>
+            <span>{languageName}</span>
+          </div>
+        </div>
+        <div className={styles.window}>{editor}</div>
+      </>
+    );
+  };
 
   return (
     <div
@@ -43,31 +80,35 @@ const Auth0Frame = () => {
             <span className={styles.gridlinesVertical} data-grid></span>
           </>
         )}
-        <div className={styles.toolbar}>
-          <div className={styles.controls}>
-            <span className={styles.control}></span>
-            <span className={styles.control}></span>
-            <span className={styles.control}></span>
-          </div>
-          <div className={styles.badge} data-value={fileName}>
-            <input
-              type="text"
-              value={fileName}
-              onChange={(event) => setFileName(event.target.value)}
-              spellCheck={false}
-              tabIndex={-1}
-              size={1}
-            />
-            {fileName.length === 0 ? <span data-ignore-in-export>Untitled</span> : null}
-          </div>
-          <div className={styles.runtime} data-value={subtitleDisplayValue}>
-            <span>{subtitleFallback}</span>
-          </div>
-        </div>
+        {isMulti ? (
+          <CodeBlocks renderWindow={renderWindow} />
+        ) : (
+          <>
+            <div className={styles.toolbar}>
+              <div className={styles.controls}>
+                <span className={styles.control}></span>
+                <span className={styles.control}></span>
+                <span className={styles.control}></span>
+              </div>
+              <div className={styles.badge} data-value={fileName}>
+                <input
+                  type="text"
+                  value={fileName}
+                  onChange={(event) => setFileName(event.target.value)}
+                  spellCheck={false}
+                  tabIndex={-1}
+                  size={1}
+                />
+                {fileName.length === 0 ? <span data-ignore-in-export>Untitled</span> : null}
+              </div>
+              <div className={styles.runtime} data-value={subtitleDisplayValue}>
+                <span>{subtitleFallback}</span>
+              </div>
+            </div>
 
-        <div className={styles.window}>
-          <Editor />
-        </div>
+            <div className={styles.window}>{primaryBlockId ? <Editor blockId={primaryBlockId} /> : null}</div>
+          </>
+        )}
       </div>
     </div>
   );

--- a/app/(navigation)/(code)/components/frames/AwsFrame.tsx
+++ b/app/(navigation)/(code)/components/frames/AwsFrame.tsx
@@ -4,7 +4,9 @@ import { useAtom, useAtomValue } from "jotai";
 import { showBackgroundAtom } from "../../store";
 import { paddingAtom } from "../../store/padding";
 import { themeDarkModeAtom } from "../../store/themes";
+import { useIsMultiBlock, usePrimaryBlockId } from "../../hooks/usePrimaryBlockId";
 
+import CodeBlocks from "../CodeBlocks";
 import Editor from "../Editor";
 import sharedStyles from "./DefaultFrame.module.css";
 import styles from "./AwsFrame.module.css";
@@ -13,6 +15,8 @@ const AwsFrame = () => {
   const darkMode = useAtomValue(themeDarkModeAtom);
   const [padding] = useAtom(paddingAtom);
   const [showBackground] = useAtom(showBackgroundAtom);
+  const isMulti = useIsMultiBlock();
+  const primaryBlockId = usePrimaryBlockId();
 
   return (
     <div
@@ -26,13 +30,27 @@ const AwsFrame = () => {
       style={{ padding }}
     >
       {!showBackground && <div data-ignore-in-export className={sharedStyles.transparentPattern}></div>}
-      <div className={styles.awsWindow}>
-        <span className={styles.awsGridlinesHorizontal} data-grid></span>
-        <span className={styles.awsGridlinesVertical} data-grid></span>
-        <span className={styles.awsBracketLeft} data-grid></span>
-        <span className={styles.awsBracketRight} data-grid></span>
-        <Editor />
-      </div>
+      {isMulti ? (
+        <CodeBlocks
+          windowClassName={styles.awsWindow}
+          renderChrome={() => (
+            <>
+              <span className={styles.awsGridlinesHorizontal} data-grid />
+              <span className={styles.awsGridlinesVertical} data-grid />
+              <span className={styles.awsBracketLeft} data-grid />
+              <span className={styles.awsBracketRight} data-grid />
+            </>
+          )}
+        />
+      ) : (
+        <div className={styles.awsWindow}>
+          <span className={styles.awsGridlinesHorizontal} data-grid></span>
+          <span className={styles.awsGridlinesVertical} data-grid></span>
+          <span className={styles.awsBracketLeft} data-grid></span>
+          <span className={styles.awsBracketRight} data-grid></span>
+          {primaryBlockId ? <Editor blockId={primaryBlockId} /> : null}
+        </div>
+      )}
     </div>
   );
 };

--- a/app/(navigation)/(code)/components/frames/BrowserbaseFrame.tsx
+++ b/app/(navigation)/(code)/components/frames/BrowserbaseFrame.tsx
@@ -1,10 +1,13 @@
 import classNames from "classnames";
-import { useAtom, useAtomValue } from "jotai";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
 
 import { fileNameAtom, showBackgroundAtom } from "../../store";
+import { updateBlockAtom, type CodeBlock } from "../../store/blocks";
 import { paddingAtom } from "../../store/padding";
 import { themeDarkModeAtom } from "../../store/themes";
+import { useIsMultiBlock, usePrimaryBlockId } from "../../hooks/usePrimaryBlockId";
 
+import CodeBlocks from "../CodeBlocks";
 import Editor from "../Editor";
 import sharedStyles from "./DefaultFrame.module.css";
 import styles from "./BrowserbaseFrame.module.css";
@@ -17,6 +20,30 @@ const BrowserbaseFrame = () => {
   const [padding] = useAtom(paddingAtom);
   const [showBackground] = useAtom(showBackgroundAtom);
   const [fileName, setFileName] = useAtom(fileNameAtom);
+  const isMulti = useIsMultiBlock();
+  const primaryBlockId = usePrimaryBlockId();
+  const updateBlock = useSetAtom(updateBlockAtom);
+
+  const renderChrome = (block: CodeBlock, index: number) => (
+    <div className={classNames(sharedStyles.header, styles.header)}>
+      <div className={sharedStyles.controls}>
+        <div className={sharedStyles.control}></div>
+        <div className={sharedStyles.control}></div>
+        <div className={sharedStyles.control}></div>
+      </div>
+      <div className={classNames(sharedStyles.fileName, styles.fileName)}>
+        <input
+          type="text"
+          value={block.title}
+          onChange={(event) => updateBlock({ blockId: block.id, update: { title: event.target.value } })}
+          spellCheck={false}
+          tabIndex={-1}
+        />
+        {block.title.length === 0 ? <span data-ignore-in-export>{`Untitled-${index + 1}`}</span> : null}
+      </div>
+      <div />
+    </div>
+  );
 
   return (
     <div
@@ -48,27 +75,31 @@ const BrowserbaseFrame = () => {
           ))}
         </div>
       )}
-      <div className={styles.window}>
-        <div className={classNames(sharedStyles.header, styles.header)}>
-          <div className={sharedStyles.controls}>
-            <div className={sharedStyles.control}></div>
-            <div className={sharedStyles.control}></div>
-            <div className={sharedStyles.control}></div>
+      {isMulti ? (
+        <CodeBlocks windowClassName={styles.window} renderChrome={renderChrome} />
+      ) : (
+        <div className={styles.window}>
+          <div className={classNames(sharedStyles.header, styles.header)}>
+            <div className={sharedStyles.controls}>
+              <div className={sharedStyles.control}></div>
+              <div className={sharedStyles.control}></div>
+              <div className={sharedStyles.control}></div>
+            </div>
+            <div className={classNames(sharedStyles.fileName, styles.fileName)}>
+              <input
+                type="text"
+                value={fileName}
+                onChange={(event) => setFileName(event.target.value)}
+                spellCheck={false}
+                tabIndex={-1}
+              />
+              {fileName.length === 0 ? <span data-ignore-in-export>Untitled-1</span> : null}
+            </div>
+            <div />
           </div>
-          <div className={classNames(sharedStyles.fileName, styles.fileName)}>
-            <input
-              type="text"
-              value={fileName}
-              onChange={(event) => setFileName(event.target.value)}
-              spellCheck={false}
-              tabIndex={-1}
-            />
-            {fileName.length === 0 ? <span data-ignore-in-export>Untitled-1</span> : null}
-          </div>
-          <div />
+          {primaryBlockId ? <Editor blockId={primaryBlockId} /> : null}
         </div>
-        <Editor />
-      </div>
+      )}
     </div>
   );
 };

--- a/app/(navigation)/(code)/components/frames/ClerkFrame.tsx
+++ b/app/(navigation)/(code)/components/frames/ClerkFrame.tsx
@@ -5,7 +5,9 @@ import { showBackgroundAtom } from "../../store";
 import { paddingAtom } from "../../store/padding";
 import { themeDarkModeAtom } from "../../store/themes";
 import clerkPattern from "../../assets/clerk/pattern.svg?url";
+import { useIsMultiBlock, usePrimaryBlockId } from "../../hooks/usePrimaryBlockId";
 
+import CodeBlocks from "../CodeBlocks";
 import Editor from "../Editor";
 import sharedStyles from "./DefaultFrame.module.css";
 import styles from "./ClerkFrame.module.css";
@@ -14,6 +16,8 @@ const ClerkFrame = () => {
   const darkMode = useAtomValue(themeDarkModeAtom);
   const [padding] = useAtom(paddingAtom);
   const [showBackground] = useAtom(showBackgroundAtom);
+  const isMulti = useIsMultiBlock();
+  const primaryBlockId = usePrimaryBlockId();
 
   return (
     <div
@@ -28,11 +32,16 @@ const ClerkFrame = () => {
     >
       {!showBackground && <div data-ignore-in-export className={sharedStyles.transparentPattern}></div>}
       {showBackground && <img src={clerkPattern} alt="" className={styles.pattern} />}
-      <div className={styles.window}>
-        <div className={styles.code}>
-          <Editor />
+      {isMulti ? (
+        <CodeBlocks
+          windowClassName={styles.window}
+          renderEditor={(_block, _index, editor) => <div className={styles.code}>{editor}</div>}
+        />
+      ) : (
+        <div className={styles.window}>
+          <div className={styles.code}>{primaryBlockId ? <Editor blockId={primaryBlockId} /> : null}</div>
         </div>
-      </div>
+      )}
     </div>
   );
 };

--- a/app/(navigation)/(code)/components/frames/CloudflareFrame.tsx
+++ b/app/(navigation)/(code)/components/frames/CloudflareFrame.tsx
@@ -1,12 +1,15 @@
 import classNames from "classnames";
-import { useAtom, useAtomValue } from "jotai";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
 
 import { fileNameAtom, showBackgroundAtom } from "../../store";
-import { selectedLanguageAtom } from "../../store/code";
+import { updateBlockAtom, type CodeBlock } from "../../store/blocks";
+import { getBlockLanguage, selectedLanguageAtom } from "../../store/code";
 import { flashShownAtom } from "../../store/flash";
 import { paddingAtom } from "../../store/padding";
 import { themeDarkModeAtom } from "../../store/themes";
+import { useIsMultiBlock, usePrimaryBlockId } from "../../hooks/usePrimaryBlockId";
 
+import CodeBlocks from "../CodeBlocks";
 import Editor from "../Editor";
 import sharedStyles from "./DefaultFrame.module.css";
 import styles from "./CloudflareFrame.module.css";
@@ -18,6 +21,46 @@ const CloudflareFrame = () => {
   const [fileName, setFileName] = useAtom(fileNameAtom);
   const [selectedLanguage] = useAtom(selectedLanguageAtom);
   const flashShown = useAtomValue(flashShownAtom);
+  const isMulti = useIsMultiBlock();
+  const primaryBlockId = usePrimaryBlockId();
+  const updateBlock = useSetAtom(updateBlockAtom);
+
+  const renderChrome = (block: CodeBlock, index: number) => (
+    <>
+      <span className={styles.gridlinesHorizontal} data-grid></span>
+      <span className={styles.gridlinesVertical} data-grid></span>
+      {block.title.length > 0 ? (
+        <div className={styles.header}>
+          <div className={classNames(sharedStyles.fileName, styles.fileName)} data-value={block.title}>
+            <input
+              type="text"
+              value={block.title}
+              onChange={(event) => updateBlock({ blockId: block.id, update: { title: event.target.value } })}
+              spellCheck={false}
+              tabIndex={-1}
+              size={1}
+            />
+          </div>
+          <span className={styles.language}>{getBlockLanguage(block)?.name}</span>
+        </div>
+      ) : flashShown ? null : (
+        <div className={styles.header} data-ignore-in-export>
+          <div className={classNames(sharedStyles.fileName, styles.fileName)} data-value={block.title}>
+            <input
+              type="text"
+              value={block.title}
+              onChange={(event) => updateBlock({ blockId: block.id, update: { title: event.target.value } })}
+              spellCheck={false}
+              tabIndex={-1}
+              size={1}
+            />
+            <span>{`Untitled-${index + 1}`}</span>
+          </div>
+          <span className={styles.language}>{getBlockLanguage(block)?.name}</span>
+        </div>
+      )}
+    </>
+  );
 
   return (
     <div
@@ -31,41 +74,45 @@ const CloudflareFrame = () => {
       style={{ padding }}
     >
       {!showBackground && <div data-ignore-in-export className={sharedStyles.transparentPattern}></div>}
-      <div className={styles.window}>
-        <span className={styles.gridlinesHorizontal} data-grid></span>
-        <span className={styles.gridlinesVertical} data-grid></span>
-        {fileName.length > 0 ? (
-          <div className={styles.header}>
-            <div className={classNames(sharedStyles.fileName, styles.fileName)} data-value={fileName}>
-              <input
-                type="text"
-                value={fileName}
-                onChange={(event) => setFileName(event.target.value)}
-                spellCheck={false}
-                tabIndex={-1}
-                size={1}
-              />
+      {isMulti ? (
+        <CodeBlocks windowClassName={styles.window} renderChrome={renderChrome} />
+      ) : (
+        <div className={styles.window}>
+          <span className={styles.gridlinesHorizontal} data-grid></span>
+          <span className={styles.gridlinesVertical} data-grid></span>
+          {fileName.length > 0 ? (
+            <div className={styles.header}>
+              <div className={classNames(sharedStyles.fileName, styles.fileName)} data-value={fileName}>
+                <input
+                  type="text"
+                  value={fileName}
+                  onChange={(event) => setFileName(event.target.value)}
+                  spellCheck={false}
+                  tabIndex={-1}
+                  size={1}
+                />
+              </div>
+              <span className={styles.language}>{selectedLanguage?.name}</span>
             </div>
-            <span className={styles.language}>{selectedLanguage?.name}</span>
-          </div>
-        ) : flashShown ? null : (
-          <div className={styles.header} data-ignore-in-export>
-            <div className={classNames(sharedStyles.fileName, styles.fileName)} data-value={fileName}>
-              <input
-                type="text"
-                value={fileName}
-                onChange={(event) => setFileName(event.target.value)}
-                spellCheck={false}
-                tabIndex={-1}
-                size={1}
-              />
-              <span>Untitled-1</span>
+          ) : flashShown ? null : (
+            <div className={styles.header} data-ignore-in-export>
+              <div className={classNames(sharedStyles.fileName, styles.fileName)} data-value={fileName}>
+                <input
+                  type="text"
+                  value={fileName}
+                  onChange={(event) => setFileName(event.target.value)}
+                  spellCheck={false}
+                  tabIndex={-1}
+                  size={1}
+                />
+                <span>Untitled-1</span>
+              </div>
+              <span className={styles.language}>{selectedLanguage?.name}</span>
             </div>
-            <span className={styles.language}>{selectedLanguage?.name}</span>
-          </div>
-        )}
-        <Editor />
-      </div>
+          )}
+          {primaryBlockId ? <Editor blockId={primaryBlockId} /> : null}
+        </div>
+      )}
     </div>
   );
 };

--- a/app/(navigation)/(code)/components/frames/CloudflareFrame.tsx
+++ b/app/(navigation)/(code)/components/frames/CloudflareFrame.tsx
@@ -29,36 +29,20 @@ const CloudflareFrame = () => {
     <>
       <span className={styles.gridlinesHorizontal} data-grid></span>
       <span className={styles.gridlinesVertical} data-grid></span>
-      {block.title.length > 0 ? (
-        <div className={styles.header}>
-          <div className={classNames(sharedStyles.fileName, styles.fileName)} data-value={block.title}>
-            <input
-              type="text"
-              value={block.title}
-              onChange={(event) => updateBlock({ blockId: block.id, update: { title: event.target.value } })}
-              spellCheck={false}
-              tabIndex={-1}
-              size={1}
-            />
-          </div>
-          <span className={styles.language}>{getBlockLanguage(block)?.name}</span>
+      <div className={styles.header}>
+        <div className={classNames(sharedStyles.fileName, styles.fileName)} data-value={block.title}>
+          <input
+            type="text"
+            value={block.title}
+            onChange={(event) => updateBlock({ blockId: block.id, update: { title: event.target.value } })}
+            spellCheck={false}
+            tabIndex={-1}
+            size={1}
+          />
+          {block.title.length === 0 ? <span data-ignore-in-export>{`Untitled-${index + 1}`}</span> : null}
         </div>
-      ) : flashShown ? null : (
-        <div className={styles.header} data-ignore-in-export>
-          <div className={classNames(sharedStyles.fileName, styles.fileName)} data-value={block.title}>
-            <input
-              type="text"
-              value={block.title}
-              onChange={(event) => updateBlock({ blockId: block.id, update: { title: event.target.value } })}
-              spellCheck={false}
-              tabIndex={-1}
-              size={1}
-            />
-            <span>{`Untitled-${index + 1}`}</span>
-          </div>
-          <span className={styles.language}>{getBlockLanguage(block)?.name}</span>
-        </div>
-      )}
+        <span className={styles.language}>{getBlockLanguage(block)?.name}</span>
+      </div>
     </>
   );
 

--- a/app/(navigation)/(code)/components/frames/DefaultFrame.tsx
+++ b/app/(navigation)/(code)/components/frames/DefaultFrame.tsx
@@ -1,10 +1,13 @@
 import classNames from "classnames";
-import { useAtom, useAtomValue } from "jotai";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
 
 import { fileNameAtom, showBackgroundAtom } from "../../store";
 import { paddingAtom } from "../../store/padding";
 import { themeAtom, themeBackgroundAtom, themeDarkModeAtom } from "../../store/themes";
 import useIsSafari from "../../util/useIsSafari";
+import { useIsMultiBlock, usePrimaryBlockId } from "../../hooks/usePrimaryBlockId";
+import { updateBlockAtom, type CodeBlock } from "../../store/blocks";
+import CodeBlocks from "../CodeBlocks";
 import Editor from "../Editor";
 import styles from "./DefaultFrame.module.css";
 
@@ -16,6 +19,34 @@ const DefaultFrame = () => {
   const [themeBackground] = useAtom(themeBackgroundAtom);
   const [theme] = useAtom(themeAtom);
   const darkMode = useAtomValue(themeDarkModeAtom);
+  const isMulti = useIsMultiBlock();
+  const primaryBlockId = usePrimaryBlockId();
+  const updateBlock = useSetAtom(updateBlockAtom);
+
+  const windowClassName = classNames(styles.window, {
+    [styles.withBorder]: !isSafari,
+    [styles.withShadow]: !isSafari && showBackground,
+  });
+
+  const renderChrome = (block: CodeBlock, index: number) => (
+    <div className={styles.header}>
+      <div className={styles.controls}>
+        <div className={styles.control}></div>
+        <div className={styles.control}></div>
+        <div className={styles.control}></div>
+      </div>
+      <div className={styles.fileName}>
+        <input
+          type="text"
+          value={block.title}
+          onChange={(event) => updateBlock({ blockId: block.id, update: { title: event.target.value } })}
+          spellCheck={false}
+          tabIndex={-1}
+        />
+        {block.title.length === 0 ? <span data-ignore-in-export>{`Untitled-${index + 1}`}</span> : null}
+      </div>
+    </div>
+  );
 
   return (
     <div
@@ -31,31 +62,30 @@ const DefaultFrame = () => {
       }}
     >
       {!showBackground && <div data-ignore-in-export className={styles.transparentPattern}></div>}
-      <div
-        className={classNames(styles.window, {
-          [styles.withBorder]: !isSafari,
-          [styles.withShadow]: !isSafari && showBackground,
-        })}
-      >
-        <div className={styles.header}>
-          <div className={styles.controls}>
-            <div className={styles.control}></div>
-            <div className={styles.control}></div>
-            <div className={styles.control}></div>
+      {isMulti ? (
+        <CodeBlocks windowClassName={windowClassName} renderChrome={renderChrome} />
+      ) : (
+        <div className={windowClassName}>
+          <div className={styles.header}>
+            <div className={styles.controls}>
+              <div className={styles.control}></div>
+              <div className={styles.control}></div>
+              <div className={styles.control}></div>
+            </div>
+            <div className={styles.fileName}>
+              <input
+                type="text"
+                value={fileName}
+                onChange={(event) => setFileName(event.target.value)}
+                spellCheck={false}
+                tabIndex={-1}
+              />
+              {fileName.length === 0 ? <span data-ignore-in-export>Untitled-1</span> : null}
+            </div>
           </div>
-          <div className={styles.fileName}>
-            <input
-              type="text"
-              value={fileName}
-              onChange={(event) => setFileName(event.target.value)}
-              spellCheck={false}
-              tabIndex={-1}
-            />
-            {fileName.length === 0 ? <span data-ignore-in-export>Untitled-1</span> : null}
-          </div>
+          {primaryBlockId ? <Editor blockId={primaryBlockId} /> : null}
         </div>
-        <Editor />
-      </div>
+      )}
     </div>
   );
 };

--- a/app/(navigation)/(code)/components/frames/ElevenLabsFrame.tsx
+++ b/app/(navigation)/(code)/components/frames/ElevenLabsFrame.tsx
@@ -3,10 +3,12 @@ import { useAtomValue } from "jotai";
 import { useEffect, useRef, useState } from "react";
 
 import { showBackgroundAtom, windowWidthAtom } from "../../store";
-import { codeAtom } from "../../store/code";
+import { totalCodeAtom } from "../../store/blocks";
 import { paddingAtom } from "../../store/padding";
 import { themeDarkModeAtom } from "../../store/themes";
+import { useIsMultiBlock, usePrimaryBlockId } from "../../hooks/usePrimaryBlockId";
 
+import CodeBlocks from "../CodeBlocks";
 import Editor from "../Editor";
 import sharedStyles from "./DefaultFrame.module.css";
 import styles from "./ElevenLabsFrame.module.css";
@@ -16,7 +18,9 @@ const ElevenLabsFrame = () => {
   const padding = useAtomValue(paddingAtom);
   const showBackground = useAtomValue(showBackgroundAtom);
   const windowWidth = useAtomValue(windowWidthAtom);
-  const code = useAtomValue(codeAtom);
+  const code = useAtomValue(totalCodeAtom);
+  const isMulti = useIsMultiBlock();
+  const primaryBlockId = usePrimaryBlockId();
 
   const windowRef = useRef<HTMLDivElement>(null);
   const [circleDiameter, setCircleDiameter] = useState(0);
@@ -66,37 +70,73 @@ const ElevenLabsFrame = () => {
       style={{ padding }}
     >
       {!showBackground && <div data-ignore-in-export className={sharedStyles.transparentPattern}></div>}
-      <div className={styles.window} ref={windowRef}>
-        <span
-          className={classNames(styles.circle, isTransitioning && styles.isTransitioning)}
-          style={{
-            width: `${circleDiameter}px`,
-            height: `${circleDiameter}px`,
-          }}
-        ></span>
+      {isMulti ? (
+        <div ref={windowRef}>
+          <CodeBlocks
+            windowClassName={styles.window}
+            renderChrome={() => (
+              <>
+                <span
+                  className={classNames(styles.circle, isTransitioning && styles.isTransitioning)}
+                  style={{
+                    width: `${circleDiameter}px`,
+                    height: `${circleDiameter}px`,
+                  }}
+                ></span>
 
-        <span className={styles.gridlineHorizontalTop} data-grid></span>
-        <span className={styles.gridlineHorizontalCenter} data-grid></span>
-        <span className={styles.gridlineHorizontalBottom} data-grid></span>
+                <span className={styles.gridlineHorizontalTop} data-grid></span>
+                <span className={styles.gridlineHorizontalCenter} data-grid></span>
+                <span className={styles.gridlineHorizontalBottom} data-grid></span>
 
-        <span className={styles.gridlineVerticalLeft} data-grid></span>
-        <span className={styles.gridlineVerticalCenter} data-grid></span>
-        <span className={styles.gridlineVerticalRight} data-grid></span>
+                <span className={styles.gridlineVerticalLeft} data-grid></span>
+                <span className={styles.gridlineVerticalCenter} data-grid></span>
+                <span className={styles.gridlineVerticalRight} data-grid></span>
 
-        <span className={styles.dotTopLeft} data-dot></span>
-        <span className={styles.dotTopRight} data-dot></span>
-        <span className={styles.dotBottomLeft} data-dot></span>
-        <span className={styles.dotBottomRight} data-dot></span>
+                <span className={styles.dotTopLeft} data-dot></span>
+                <span className={styles.dotTopRight} data-dot></span>
+                <span className={styles.dotBottomLeft} data-dot></span>
+                <span className={styles.dotBottomRight} data-dot></span>
 
-        <span className={styles.gridlineCornerTopLeft} data-grid></span>
-        <span className={styles.gridlineCornerTopRight} data-grid></span>
-        <span className={styles.gridlineCornerBottomRight} data-grid></span>
-        <span className={styles.gridlineCornerBottomLeft} data-grid></span>
-
-        <div className={styles.editor}>
-          <Editor />
+                <span className={styles.gridlineCornerTopLeft} data-grid></span>
+                <span className={styles.gridlineCornerTopRight} data-grid></span>
+                <span className={styles.gridlineCornerBottomRight} data-grid></span>
+                <span className={styles.gridlineCornerBottomLeft} data-grid></span>
+              </>
+            )}
+            renderEditor={(_block, _index, editor) => <div className={styles.editor}>{editor}</div>}
+          />
         </div>
-      </div>
+      ) : (
+        <div className={styles.window} ref={windowRef}>
+          <span
+            className={classNames(styles.circle, isTransitioning && styles.isTransitioning)}
+            style={{
+              width: `${circleDiameter}px`,
+              height: `${circleDiameter}px`,
+            }}
+          ></span>
+
+          <span className={styles.gridlineHorizontalTop} data-grid></span>
+          <span className={styles.gridlineHorizontalCenter} data-grid></span>
+          <span className={styles.gridlineHorizontalBottom} data-grid></span>
+
+          <span className={styles.gridlineVerticalLeft} data-grid></span>
+          <span className={styles.gridlineVerticalCenter} data-grid></span>
+          <span className={styles.gridlineVerticalRight} data-grid></span>
+
+          <span className={styles.dotTopLeft} data-dot></span>
+          <span className={styles.dotTopRight} data-dot></span>
+          <span className={styles.dotBottomLeft} data-dot></span>
+          <span className={styles.dotBottomRight} data-dot></span>
+
+          <span className={styles.gridlineCornerTopLeft} data-grid></span>
+          <span className={styles.gridlineCornerTopRight} data-grid></span>
+          <span className={styles.gridlineCornerBottomRight} data-grid></span>
+          <span className={styles.gridlineCornerBottomLeft} data-grid></span>
+
+          <div className={styles.editor}>{primaryBlockId ? <Editor blockId={primaryBlockId} /> : null}</div>
+        </div>
+      )}
     </div>
   );
 };

--- a/app/(navigation)/(code)/components/frames/FirecrawlFrame.tsx
+++ b/app/(navigation)/(code)/components/frames/FirecrawlFrame.tsx
@@ -6,7 +6,9 @@ import { showBackgroundAtom } from "../../store";
 import { exportSizeAtom } from "../../store/image";
 import { paddingAtom } from "../../store/padding";
 import { darkModeAtom } from "../../store/themes";
+import { useIsMultiBlock, usePrimaryBlockId } from "../../hooks/usePrimaryBlockId";
 
+import CodeBlocks from "../CodeBlocks";
 import Editor from "../Editor";
 import sharedStyles from "./DefaultFrame.module.css";
 import styles from "./FirecrawlFrame.module.css";
@@ -121,6 +123,8 @@ const FirecrawlFrame = () => {
   const [showBackground] = useAtom(showBackgroundAtom);
   const exportSize = useAtomValue(exportSizeAtom);
   const gridColor = darkMode ? "#444" : "#ededed";
+  const isMulti = useIsMultiBlock();
+  const primaryBlockId = usePrimaryBlockId();
 
   return (
     <div
@@ -134,17 +138,35 @@ const FirecrawlFrame = () => {
       style={{ padding, ["--frame-padding" as string]: `${padding}px` }}
     >
       {!showBackground && <div data-ignore-in-export className={sharedStyles.transparentPattern}></div>}
-      <div className={styles.window}>
-        {showBackground && (
-          <div className={styles.asciiArtContainer}>
-            <pre className={styles.asciiArt}>{FIRECRAWL_ASCII_ART}</pre>
-          </div>
-        )}
-        <Editor />
-        {showBackground && (
-          <FirecrawlFrameCanvas gridColor={gridColor} padding={padding} exportPixelRatio={exportSize} />
-        )}
-      </div>
+      {isMulti ? (
+        <div style={{ position: "relative" }}>
+          <CodeBlocks
+            windowClassName={styles.window}
+            renderChrome={() =>
+              showBackground ? (
+                <div className={styles.asciiArtContainer}>
+                  <pre className={styles.asciiArt}>{FIRECRAWL_ASCII_ART}</pre>
+                </div>
+              ) : null
+            }
+          />
+          {showBackground && (
+            <FirecrawlFrameCanvas gridColor={gridColor} padding={padding} exportPixelRatio={exportSize} />
+          )}
+        </div>
+      ) : (
+        <div className={styles.window}>
+          {showBackground && (
+            <div className={styles.asciiArtContainer}>
+              <pre className={styles.asciiArt}>{FIRECRAWL_ASCII_ART}</pre>
+            </div>
+          )}
+          {primaryBlockId ? <Editor blockId={primaryBlockId} /> : null}
+          {showBackground && (
+            <FirecrawlFrameCanvas gridColor={gridColor} padding={padding} exportPixelRatio={exportSize} />
+          )}
+        </div>
+      )}
     </div>
   );
 };

--- a/app/(navigation)/(code)/components/frames/GeminiFrame.tsx
+++ b/app/(navigation)/(code)/components/frames/GeminiFrame.tsx
@@ -1,12 +1,15 @@
 import classNames from "classnames";
-import { useAtom, useAtomValue } from "jotai";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
 
 import { fileNameAtom, showBackgroundAtom } from "../../store";
+import { updateBlockAtom, type CodeBlock } from "../../store/blocks";
 import { flashShownAtom } from "../../store/flash";
 import { paddingAtom } from "../../store/padding";
 import { themeDarkModeAtom } from "../../store/themes";
 import useIsSafari from "../../util/useIsSafari";
+import { useIsMultiBlock, usePrimaryBlockId } from "../../hooks/usePrimaryBlockId";
 
+import CodeBlocks from "../CodeBlocks";
 import Editor from "../Editor";
 import sharedStyles from "./DefaultFrame.module.css";
 import styles from "./GeminiFrame.module.css";
@@ -18,6 +21,39 @@ const GeminiFrame = () => {
   const [fileName, setFileName] = useAtom(fileNameAtom);
   const isSafari = useIsSafari();
   const flashShown = useAtomValue(flashShownAtom);
+  const isMulti = useIsMultiBlock();
+  const primaryBlockId = usePrimaryBlockId();
+  const updateBlock = useSetAtom(updateBlockAtom);
+
+  const renderChrome = (block: CodeBlock, index: number) =>
+    block.title.length > 0 ? (
+      <div className={styles.header}>
+        <div className={classNames(sharedStyles.fileName, styles.fileName)} data-value={block.title}>
+          <input
+            type="text"
+            value={block.title}
+            onChange={(event) => updateBlock({ blockId: block.id, update: { title: event.target.value } })}
+            spellCheck={false}
+            tabIndex={-1}
+            size={1}
+          />
+        </div>
+      </div>
+    ) : flashShown ? null : (
+      <div className={styles.header} data-ignore-in-export>
+        <div className={classNames(sharedStyles.fileName, styles.fileName)} data-value={block.title}>
+          <input
+            type="text"
+            value={block.title}
+            onChange={(event) => updateBlock({ blockId: block.id, update: { title: event.target.value } })}
+            spellCheck={false}
+            tabIndex={-1}
+            size={1}
+          />
+          <span>{`Untitled-${index + 1}`}</span>
+        </div>
+      </div>
+    );
 
   return (
     <div
@@ -33,40 +69,46 @@ const GeminiFrame = () => {
     >
       {!showBackground && <div data-ignore-in-export className={sharedStyles.transparentPattern}></div>}
       {showBackground && <img src="/stars.svg" alt="stars" className={styles.stars} />}
-      <div className={styles.window}>
-        {fileName.length > 0 ? (
-          <div className={styles.header}>
-            <div className={classNames(sharedStyles.fileName, styles.fileName)} data-value={fileName}>
-              <input
-                type="text"
-                value={fileName}
-                onChange={(event) => setFileName(event.target.value)}
-                spellCheck={false}
-                tabIndex={-1}
-                size={1}
-              />
+      {isMulti ? (
+        <CodeBlocks
+          windowClassName={styles.window}
+          renderChrome={renderChrome}
+          renderEditor={(_block, _index, editor) => <div>{editor}</div>}
+        />
+      ) : (
+        <div className={styles.window}>
+          {fileName.length > 0 ? (
+            <div className={styles.header}>
+              <div className={classNames(sharedStyles.fileName, styles.fileName)} data-value={fileName}>
+                <input
+                  type="text"
+                  value={fileName}
+                  onChange={(event) => setFileName(event.target.value)}
+                  spellCheck={false}
+                  tabIndex={-1}
+                  size={1}
+                />
+              </div>
             </div>
-          </div>
-        ) : flashShown ? null : (
-          <div className={styles.header} data-ignore-in-export>
-            <div className={classNames(sharedStyles.fileName, styles.fileName)} data-value={fileName}>
-              <input
-                type="text"
-                value={fileName}
-                onChange={(event) => setFileName(event.target.value)}
-                spellCheck={false}
-                tabIndex={-1}
-                size={1}
-              />
-              <span>Untitled-1</span>
+          ) : flashShown ? null : (
+            <div className={styles.header} data-ignore-in-export>
+              <div className={classNames(sharedStyles.fileName, styles.fileName)} data-value={fileName}>
+                <input
+                  type="text"
+                  value={fileName}
+                  onChange={(event) => setFileName(event.target.value)}
+                  spellCheck={false}
+                  tabIndex={-1}
+                  size={1}
+                />
+                <span>Untitled-1</span>
+              </div>
             </div>
-          </div>
-        )}
+          )}
 
-        <div>
-          <Editor />
+          <div>{primaryBlockId ? <Editor blockId={primaryBlockId} /> : null}</div>
         </div>
-      </div>
+      )}
     </div>
   );
 };

--- a/app/(navigation)/(code)/components/frames/MintlifyFrame.tsx
+++ b/app/(navigation)/(code)/components/frames/MintlifyFrame.tsx
@@ -1,12 +1,15 @@
 import classNames from "classnames";
-import { useAtom, useAtomValue } from "jotai";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
 
 import { fileNameAtom, showBackgroundAtom } from "../../store";
+import { updateBlockAtom, type CodeBlock } from "../../store/blocks";
 import { paddingAtom } from "../../store/padding";
 import { themeDarkModeAtom } from "../../store/themes";
 import mintlifyPatternDark from "../../assets/mintlify-pattern-dark.svg?url";
 import mintlifyPatternLight from "../../assets/mintlify-pattern-light.svg?url";
+import { useIsMultiBlock, usePrimaryBlockId } from "../../hooks/usePrimaryBlockId";
 
+import CodeBlocks from "../CodeBlocks";
 import Editor from "../Editor";
 import sharedStyles from "./DefaultFrame.module.css";
 import styles from "./MintlifyFrame.module.css";
@@ -16,6 +19,25 @@ const MintlifyFrame = () => {
   const [padding] = useAtom(paddingAtom);
   const [showBackground] = useAtom(showBackgroundAtom);
   const [fileName, setFileName] = useAtom(fileNameAtom);
+  const isMulti = useIsMultiBlock();
+  const primaryBlockId = usePrimaryBlockId();
+  const updateBlock = useSetAtom(updateBlockAtom);
+
+  const renderChrome = (block: CodeBlock, index: number) => (
+    <div className={styles.header}>
+      <div className={classNames(sharedStyles.fileName, styles.fileName)} data-value={block.title}>
+        <input
+          type="text"
+          value={block.title}
+          onChange={(event) => updateBlock({ blockId: block.id, update: { title: event.target.value } })}
+          spellCheck={false}
+          tabIndex={-1}
+          size={1}
+        />
+        {block.title.length === 0 ? <span>{`Untitled-${index + 1}`}</span> : null}
+      </div>
+    </div>
+  );
 
   return (
     <div
@@ -34,22 +56,26 @@ const MintlifyFrame = () => {
           <img src={darkMode ? mintlifyPatternDark : mintlifyPatternLight} alt="" className={styles.pattern} />
         </span>
       )}
-      <div className={styles.window}>
-        <div className={styles.header}>
-          <div className={classNames(sharedStyles.fileName, styles.fileName)} data-value={fileName}>
-            <input
-              type="text"
-              value={fileName}
-              onChange={(event) => setFileName(event.target.value)}
-              spellCheck={false}
-              tabIndex={-1}
-              size={1}
-            />
-            {fileName.length === 0 ? <span>Untitled-1</span> : null}
+      {isMulti ? (
+        <CodeBlocks windowClassName={styles.window} renderChrome={renderChrome} />
+      ) : (
+        <div className={styles.window}>
+          <div className={styles.header}>
+            <div className={classNames(sharedStyles.fileName, styles.fileName)} data-value={fileName}>
+              <input
+                type="text"
+                value={fileName}
+                onChange={(event) => setFileName(event.target.value)}
+                spellCheck={false}
+                tabIndex={-1}
+                size={1}
+              />
+              {fileName.length === 0 ? <span>Untitled-1</span> : null}
+            </div>
           </div>
+          {primaryBlockId ? <Editor blockId={primaryBlockId} /> : null}
         </div>
-        <Editor />
-      </div>
+      )}
     </div>
   );
 };

--- a/app/(navigation)/(code)/components/frames/NuxtFrame.tsx
+++ b/app/(navigation)/(code)/components/frames/NuxtFrame.tsx
@@ -4,7 +4,9 @@ import { useAtom, useAtomValue } from "jotai";
 import { showBackgroundAtom } from "../../store";
 import { paddingAtom } from "../../store/padding";
 import { themeDarkModeAtom } from "../../store/themes";
+import { useIsMultiBlock, usePrimaryBlockId } from "../../hooks/usePrimaryBlockId";
 
+import CodeBlocks from "../CodeBlocks";
 import Editor from "../Editor";
 import sharedStyles from "./DefaultFrame.module.css";
 import styles from "./NuxtFrame.module.css";
@@ -13,6 +15,8 @@ const NuxtFrame = () => {
   const darkMode = useAtomValue(themeDarkModeAtom);
   const [padding] = useAtom(paddingAtom);
   const [showBackground] = useAtom(showBackgroundAtom);
+  const isMulti = useIsMultiBlock();
+  const primaryBlockId = usePrimaryBlockId();
 
   return (
     <div
@@ -27,12 +31,25 @@ const NuxtFrame = () => {
     >
       {!showBackground && <div data-ignore-in-export className={sharedStyles.transparentPattern}></div>}
       <img src="/stars.svg" alt="stars" className={styles.stars} />
-      <div className={styles.window}>
-        <span data-frameborder />
-        <span data-frameborder />
-        <span data-frameborder />
-        <Editor />
-      </div>
+      {isMulti ? (
+        <CodeBlocks
+          windowClassName={styles.window}
+          renderChrome={() => (
+            <>
+              <span data-frameborder />
+              <span data-frameborder />
+              <span data-frameborder />
+            </>
+          )}
+        />
+      ) : (
+        <div className={styles.window}>
+          <span data-frameborder />
+          <span data-frameborder />
+          <span data-frameborder />
+          {primaryBlockId ? <Editor blockId={primaryBlockId} /> : null}
+        </div>
+      )}
     </div>
   );
 };

--- a/app/(navigation)/(code)/components/frames/OpenAIFrame.tsx
+++ b/app/(navigation)/(code)/components/frames/OpenAIFrame.tsx
@@ -5,7 +5,9 @@ import React from "react";
 import { showBackgroundAtom } from "../../store";
 import { paddingAtom } from "../../store/padding";
 import { themeDarkModeAtom } from "../../store/themes";
+import { useIsMultiBlock, usePrimaryBlockId } from "../../hooks/usePrimaryBlockId";
 
+import CodeBlocks from "../CodeBlocks";
 import Editor from "../Editor";
 import sharedStyles from "./DefaultFrame.module.css";
 import styles from "./OpenAIFrame.module.css";
@@ -14,6 +16,8 @@ const OpenAIFrame = () => {
   const darkMode = useAtomValue(themeDarkModeAtom);
   const [padding] = useAtom(paddingAtom);
   const [showBackground] = useAtom(showBackgroundAtom);
+  const isMulti = useIsMultiBlock();
+  const primaryBlockId = usePrimaryBlockId();
 
   return (
     <div
@@ -26,9 +30,11 @@ const OpenAIFrame = () => {
       style={{ padding, "--padding": `${padding}px` } as React.CSSProperties}
     >
       {!showBackground && <div data-ignore-in-export className={sharedStyles.transparentPattern}></div>}
-      <div className={styles.window}>
-        <Editor />
-      </div>
+      {isMulti ? (
+        <CodeBlocks windowClassName={styles.window} />
+      ) : (
+        <div className={styles.window}>{primaryBlockId ? <Editor blockId={primaryBlockId} /> : null}</div>
+      )}
     </div>
   );
 };

--- a/app/(navigation)/(code)/components/frames/PrismaFrame.tsx
+++ b/app/(navigation)/(code)/components/frames/PrismaFrame.tsx
@@ -1,11 +1,14 @@
 import classNames from "classnames";
-import { useAtom, useAtomValue } from "jotai";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
 
 import { fileNameAtom, showBackgroundAtom } from "../../store";
+import { updateBlockAtom, type CodeBlock } from "../../store/blocks";
 import { flashShownAtom } from "../../store/flash";
 import { paddingAtom } from "../../store/padding";
 import { themeDarkModeAtom } from "../../store/themes";
+import { useIsMultiBlock, usePrimaryBlockId } from "../../hooks/usePrimaryBlockId";
 
+import CodeBlocks from "../CodeBlocks";
 import Editor from "../Editor";
 import sharedStyles from "./DefaultFrame.module.css";
 import styles from "./PrismaFrame.module.css";
@@ -16,6 +19,46 @@ const PrismaFrame = () => {
   const [showBackground] = useAtom(showBackgroundAtom);
   const [fileName, setFileName] = useAtom(fileNameAtom);
   const flashShown = useAtomValue(flashShownAtom);
+  const isMulti = useIsMultiBlock();
+  const primaryBlockId = usePrimaryBlockId();
+  const updateBlock = useSetAtom(updateBlockAtom);
+
+  const renderChrome = (block: CodeBlock, index: number) => (
+    <>
+      <span data-frameborder />
+      <span data-frameborder />
+      <span data-frameborder />
+      <span data-frameborder />
+      {block.title.length > 0 ? (
+        <div className={styles.header}>
+          <div className={classNames(sharedStyles.fileName, styles.fileName)} data-value={block.title}>
+            <input
+              type="text"
+              value={block.title}
+              onChange={(event) => updateBlock({ blockId: block.id, update: { title: event.target.value } })}
+              spellCheck={false}
+              tabIndex={-1}
+              size={1}
+            />
+          </div>
+        </div>
+      ) : flashShown ? null : (
+        <div className={styles.header} data-ignore-in-export>
+          <div className={classNames(sharedStyles.fileName, styles.fileName)} data-value={block.title}>
+            <input
+              type="text"
+              value={block.title}
+              onChange={(event) => updateBlock({ blockId: block.id, update: { title: event.target.value } })}
+              spellCheck={false}
+              tabIndex={-1}
+              size={1}
+            />
+            <span>{`Untitled-${index + 1}`}</span>
+          </div>
+        </div>
+      )}
+    </>
+  );
 
   return (
     <div
@@ -29,41 +72,45 @@ const PrismaFrame = () => {
       style={{ padding }}
     >
       {!showBackground && <div data-ignore-in-export className={sharedStyles.transparentPattern}></div>}
-      <div className={styles.window}>
-        <span data-frameborder />
-        <span data-frameborder />
-        <span data-frameborder />
-        <span data-frameborder />
-        {fileName.length > 0 ? (
-          <div className={styles.header}>
-            <div className={classNames(sharedStyles.fileName, styles.fileName)} data-value={fileName}>
-              <input
-                type="text"
-                value={fileName}
-                onChange={(event) => setFileName(event.target.value)}
-                spellCheck={false}
-                tabIndex={-1}
-                size={1}
-              />
+      {isMulti ? (
+        <CodeBlocks windowClassName={styles.window} renderChrome={renderChrome} />
+      ) : (
+        <div className={styles.window}>
+          <span data-frameborder />
+          <span data-frameborder />
+          <span data-frameborder />
+          <span data-frameborder />
+          {fileName.length > 0 ? (
+            <div className={styles.header}>
+              <div className={classNames(sharedStyles.fileName, styles.fileName)} data-value={fileName}>
+                <input
+                  type="text"
+                  value={fileName}
+                  onChange={(event) => setFileName(event.target.value)}
+                  spellCheck={false}
+                  tabIndex={-1}
+                  size={1}
+                />
+              </div>
             </div>
-          </div>
-        ) : flashShown ? null : (
-          <div className={styles.header} data-ignore-in-export>
-            <div className={classNames(sharedStyles.fileName, styles.fileName)} data-value={fileName}>
-              <input
-                type="text"
-                value={fileName}
-                onChange={(event) => setFileName(event.target.value)}
-                spellCheck={false}
-                tabIndex={-1}
-                size={1}
-              />
-              <span>Untitled-1</span>
+          ) : flashShown ? null : (
+            <div className={styles.header} data-ignore-in-export>
+              <div className={classNames(sharedStyles.fileName, styles.fileName)} data-value={fileName}>
+                <input
+                  type="text"
+                  value={fileName}
+                  onChange={(event) => setFileName(event.target.value)}
+                  spellCheck={false}
+                  tabIndex={-1}
+                  size={1}
+                />
+                <span>Untitled-1</span>
+              </div>
             </div>
-          </div>
-        )}
-        <Editor />
-      </div>
+          )}
+          {primaryBlockId ? <Editor blockId={primaryBlockId} /> : null}
+        </div>
+      )}
     </div>
   );
 };

--- a/app/(navigation)/(code)/components/frames/ResendFrame.tsx
+++ b/app/(navigation)/(code)/components/frames/ResendFrame.tsx
@@ -1,11 +1,14 @@
 import classNames from "classnames";
-import { useAtom, useAtomValue } from "jotai";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
 
 import { fileNameAtom, showBackgroundAtom } from "../../store";
-import { selectedLanguageAtom } from "../../store/code";
+import { updateBlockAtom, type CodeBlock } from "../../store/blocks";
+import { getBlockLanguage, selectedLanguageAtom } from "../../store/code";
 import { paddingAtom } from "../../store/padding";
 import { themeDarkModeAtom } from "../../store/themes";
+import { useIsMultiBlock, usePrimaryBlockId } from "../../hooks/usePrimaryBlockId";
 
+import CodeBlocks from "../CodeBlocks";
 import Editor from "../Editor";
 import sharedStyles from "./DefaultFrame.module.css";
 import styles from "./ResendFrame.module.css";
@@ -16,6 +19,26 @@ const ResendFrame = () => {
   const [showBackground] = useAtom(showBackgroundAtom);
   const [fileName, setFileName] = useAtom(fileNameAtom);
   const selectedLanguage = useAtomValue(selectedLanguageAtom);
+  const isMulti = useIsMultiBlock();
+  const primaryBlockId = usePrimaryBlockId();
+  const updateBlock = useSetAtom(updateBlockAtom);
+
+  const renderChrome = (block: CodeBlock, index: number) => (
+    <div className={styles.header}>
+      <div className={classNames(sharedStyles.fileName, styles.fileName)} data-value={block.title}>
+        <input
+          type="text"
+          value={block.title}
+          onChange={(event) => updateBlock({ blockId: block.id, update: { title: event.target.value } })}
+          spellCheck={false}
+          tabIndex={-1}
+          size={1}
+        />
+        {block.title.length === 0 ? <span>{`Untitled-${index + 1}`}</span> : null}
+      </div>
+      <span className={styles.language}>{getBlockLanguage(block)?.name}</span>
+    </div>
+  );
 
   return (
     <div
@@ -28,23 +51,27 @@ const ResendFrame = () => {
       style={{ padding }}
     >
       {!showBackground && <div data-ignore-in-export className={sharedStyles.transparentPattern}></div>}
-      <div className={styles.window}>
-        <div className={styles.header}>
-          <div className={classNames(sharedStyles.fileName, styles.fileName)} data-value={fileName}>
-            <input
-              type="text"
-              value={fileName}
-              onChange={(event) => setFileName(event.target.value)}
-              spellCheck={false}
-              tabIndex={-1}
-              size={1}
-            />
-            {fileName.length === 0 ? <span>Untitled-1</span> : null}
+      {isMulti ? (
+        <CodeBlocks windowClassName={styles.window} renderChrome={renderChrome} />
+      ) : (
+        <div className={styles.window}>
+          <div className={styles.header}>
+            <div className={classNames(sharedStyles.fileName, styles.fileName)} data-value={fileName}>
+              <input
+                type="text"
+                value={fileName}
+                onChange={(event) => setFileName(event.target.value)}
+                spellCheck={false}
+                tabIndex={-1}
+                size={1}
+              />
+              {fileName.length === 0 ? <span>Untitled-1</span> : null}
+            </div>
+            <span className={styles.language}>{selectedLanguage?.name}</span>
           </div>
-          <span className={styles.language}>{selectedLanguage?.name}</span>
+          {primaryBlockId ? <Editor blockId={primaryBlockId} /> : null}
         </div>
-        <Editor />
-      </div>
+      )}
     </div>
   );
 };

--- a/app/(navigation)/(code)/components/frames/StripeFrame.tsx
+++ b/app/(navigation)/(code)/components/frames/StripeFrame.tsx
@@ -3,11 +3,13 @@ import { useAtom, useAtomValue } from "jotai";
 import React, { useEffect, useRef, useState } from "react";
 
 import { showBackgroundAtom, windowWidthAtom } from "../../store";
-import { codeAtom } from "../../store/code";
+import { totalCodeAtom } from "../../store/blocks";
 import { paddingAtom } from "../../store/padding";
 import { themeDarkModeAtom } from "../../store/themes";
 import useIsSafari from "../../util/useIsSafari";
+import { useIsMultiBlock, usePrimaryBlockId } from "../../hooks/usePrimaryBlockId";
 
+import CodeBlocks from "../CodeBlocks";
 import Editor from "../Editor";
 import sharedStyles from "./DefaultFrame.module.css";
 import styles from "./StripeFrame.module.css";
@@ -16,9 +18,11 @@ const StripeFrame = () => {
   const darkMode = useAtomValue(themeDarkModeAtom);
   const [padding] = useAtom(paddingAtom);
   const [showBackground] = useAtom(showBackgroundAtom);
-  const code = useAtomValue(codeAtom);
+  const code = useAtomValue(totalCodeAtom);
   const windowWidth = useAtomValue(windowWidthAtom);
   const isSafari = useIsSafari();
+  const isMulti = useIsMultiBlock();
+  const primaryBlockId = usePrimaryBlockId();
 
   const windowRef = useRef<HTMLDivElement>(null);
   const frameRef = useRef<HTMLDivElement>(null);
@@ -57,6 +61,8 @@ const StripeFrame = () => {
       clearTimeout(endId);
     };
   }, [padding]);
+
+  const windowClassName = classNames(styles.window, isSafari && styles.isSafari);
 
   return (
     <div
@@ -105,9 +111,15 @@ const StripeFrame = () => {
         </div>
       )}
 
-      <div className={classNames(styles.window, isSafari && styles.isSafari)} ref={windowRef}>
-        <Editor />
-      </div>
+      {isMulti ? (
+        <div ref={windowRef}>
+          <CodeBlocks windowClassName={windowClassName} />
+        </div>
+      ) : (
+        <div className={windowClassName} ref={windowRef}>
+          {primaryBlockId ? <Editor blockId={primaryBlockId} /> : null}
+        </div>
+      )}
     </div>
   );
 };

--- a/app/(navigation)/(code)/components/frames/SupabaseFrame.tsx
+++ b/app/(navigation)/(code)/components/frames/SupabaseFrame.tsx
@@ -4,7 +4,9 @@ import { useAtom, useAtomValue } from "jotai";
 import { showBackgroundAtom } from "../../store";
 import { paddingAtom } from "../../store/padding";
 import { themeDarkModeAtom } from "../../store/themes";
+import { useIsMultiBlock, usePrimaryBlockId } from "../../hooks/usePrimaryBlockId";
 
+import CodeBlocks from "../CodeBlocks";
 import Editor from "../Editor";
 import sharedStyles from "./DefaultFrame.module.css";
 import styles from "./SupabaseFrame.module.css";
@@ -13,6 +15,8 @@ const SupabaseFrame = () => {
   const darkMode = useAtomValue(themeDarkModeAtom);
   const [padding] = useAtom(paddingAtom);
   const [showBackground] = useAtom(showBackgroundAtom);
+  const isMulti = useIsMultiBlock();
+  const primaryBlockId = usePrimaryBlockId();
 
   return (
     <div
@@ -26,9 +30,11 @@ const SupabaseFrame = () => {
       style={{ padding }}
     >
       {!showBackground && <div data-ignore-in-export className={sharedStyles.transparentPattern}></div>}
-      <div className={styles.window}>
-        <Editor />
-      </div>
+      {isMulti ? (
+        <CodeBlocks windowClassName={styles.window} />
+      ) : (
+        <div className={styles.window}>{primaryBlockId ? <Editor blockId={primaryBlockId} /> : null}</div>
+      )}
     </div>
   );
 };

--- a/app/(navigation)/(code)/components/frames/TailwindFrame.tsx
+++ b/app/(navigation)/(code)/components/frames/TailwindFrame.tsx
@@ -2,11 +2,13 @@ import classNames from "classnames";
 import { useAtom, useAtomValue } from "jotai";
 
 import beams from "../../assets/tailwind/beams.png";
-import { fileNameAtom, showBackgroundAtom } from "../../store";
+import { showBackgroundAtom } from "../../store";
 import { paddingAtom } from "../../store/padding";
 import { themeDarkModeAtom } from "../../store/themes";
 import useIsSafari from "../../util/useIsSafari";
+import { useIsMultiBlock, usePrimaryBlockId } from "../../hooks/usePrimaryBlockId";
 
+import CodeBlocks from "../CodeBlocks";
 import Editor from "../Editor";
 import sharedStyles from "./DefaultFrame.module.css";
 import styles from "./TailwindFrame.module.css";
@@ -15,8 +17,33 @@ const TailwindFrame = () => {
   const darkMode = useAtomValue(themeDarkModeAtom);
   const [padding] = useAtom(paddingAtom);
   const [showBackground] = useAtom(showBackgroundAtom);
-  useAtom(fileNameAtom);
   const isSafari = useIsSafari();
+  const isMulti = useIsMultiBlock();
+  const primaryBlockId = usePrimaryBlockId();
+
+  const renderChrome = () => (
+    <>
+      {showBackground && (
+        <>
+          <span className={styles.gridlinesHorizontal} data-grid></span>
+          <span className={styles.gridlinesVertical} data-grid></span>
+          <div className={styles.gradient}>
+            <div>
+              <div className={styles.gradient1}></div>
+              <div className={styles.gradient2}></div>
+            </div>
+          </div>
+        </>
+      )}
+      <div className={classNames(sharedStyles.header, styles.header)}>
+        <div className={sharedStyles.controls}>
+          <div className={classNames(sharedStyles.control, styles.control)}></div>
+          <div className={classNames(sharedStyles.control, styles.control)}></div>
+          <div className={classNames(sharedStyles.control, styles.control)}></div>
+        </div>
+      </div>
+    </>
+  );
 
   return (
     <div
@@ -33,28 +60,32 @@ const TailwindFrame = () => {
       {!showBackground && <div data-ignore-in-export className={sharedStyles.transparentPattern}></div>}
       {showBackground && <img src={beams.src} alt="beams" className={styles.beams} />}
       <div className={styles.beams} />
-      <div className={styles.window}>
-        {showBackground && (
-          <>
-            <span className={styles.gridlinesHorizontal} data-grid></span>
-            <span className={styles.gridlinesVertical} data-grid></span>
-            <div className={styles.gradient}>
-              <div>
-                <div className={styles.gradient1}></div>
-                <div className={styles.gradient2}></div>
+      {isMulti ? (
+        <CodeBlocks windowClassName={styles.window} renderChrome={renderChrome} />
+      ) : (
+        <div className={styles.window}>
+          {showBackground && (
+            <>
+              <span className={styles.gridlinesHorizontal} data-grid></span>
+              <span className={styles.gridlinesVertical} data-grid></span>
+              <div className={styles.gradient}>
+                <div>
+                  <div className={styles.gradient1}></div>
+                  <div className={styles.gradient2}></div>
+                </div>
               </div>
+            </>
+          )}
+          <div className={classNames(sharedStyles.header, styles.header)}>
+            <div className={sharedStyles.controls}>
+              <div className={classNames(sharedStyles.control, styles.control)}></div>
+              <div className={classNames(sharedStyles.control, styles.control)}></div>
+              <div className={classNames(sharedStyles.control, styles.control)}></div>
             </div>
-          </>
-        )}
-        <div className={classNames(sharedStyles.header, styles.header)}>
-          <div className={sharedStyles.controls}>
-            <div className={classNames(sharedStyles.control, styles.control)}></div>
-            <div className={classNames(sharedStyles.control, styles.control)}></div>
-            <div className={classNames(sharedStyles.control, styles.control)}></div>
           </div>
+          {primaryBlockId ? <Editor blockId={primaryBlockId} /> : null}
         </div>
-        <Editor />
-      </div>
+      )}
     </div>
   );
 };

--- a/app/(navigation)/(code)/components/frames/TriggerdevFrame.tsx
+++ b/app/(navigation)/(code)/components/frames/TriggerdevFrame.tsx
@@ -1,13 +1,16 @@
 import classNames from "classnames";
-import { useAtom, useAtomValue } from "jotai";
+import { useAtom, useAtomValue, useSetAtom } from "jotai";
 
 import { fileNameAtom, showBackgroundAtom } from "../../store";
-import { selectedLanguageAtom } from "../../store/code";
+import { updateBlockAtom, type CodeBlock } from "../../store/blocks";
+import { getBlockLanguage, selectedLanguageAtom } from "../../store/code";
 import { flashShownAtom } from "../../store/flash";
 import { paddingAtom } from "../../store/padding";
 import { themeBackgroundAtom, themeDarkModeAtom } from "../../store/themes";
 import triggerPattern from "../../assets/triggerdev/pattern.svg?url";
+import { useIsMultiBlock, usePrimaryBlockId } from "../../hooks/usePrimaryBlockId";
 
+import CodeBlocks from "../CodeBlocks";
 import Editor from "../Editor";
 import sharedStyles from "./DefaultFrame.module.css";
 import styles from "./TriggerdevFrame.module.css";
@@ -20,6 +23,46 @@ const TriggerdevFrame = () => {
   const [fileName, setFileName] = useAtom(fileNameAtom);
   const [selectedLanguage] = useAtom(selectedLanguageAtom);
   const flashShown = useAtomValue(flashShownAtom);
+  const isMulti = useIsMultiBlock();
+  const primaryBlockId = usePrimaryBlockId();
+  const updateBlock = useSetAtom(updateBlockAtom);
+
+  const renderChrome = (block: CodeBlock, index: number) => (
+    <>
+      <span className={styles.gridlinesHorizontal} data-grid></span>
+      <span className={styles.gridlinesVertical} data-grid></span>
+      {block.title.length > 0 ? (
+        <div className={styles.header}>
+          <div className={classNames(sharedStyles.fileName, styles.fileName)} data-value={block.title}>
+            <input
+              type="text"
+              value={block.title}
+              onChange={(event) => updateBlock({ blockId: block.id, update: { title: event.target.value } })}
+              spellCheck={false}
+              tabIndex={-1}
+              size={1}
+            />
+          </div>
+          <span className={styles.language}>{getBlockLanguage(block)?.name}</span>
+        </div>
+      ) : flashShown ? null : (
+        <div className={styles.header} data-ignore-in-export>
+          <div className={classNames(sharedStyles.fileName, styles.fileName)} data-value={block.title}>
+            <input
+              type="text"
+              value={block.title}
+              onChange={(event) => updateBlock({ blockId: block.id, update: { title: event.target.value } })}
+              spellCheck={false}
+              tabIndex={-1}
+              size={1}
+            />
+            <span>{`Untitled-${index + 1}`}</span>
+          </div>
+          <span className={styles.language}>{getBlockLanguage(block)?.name}</span>
+        </div>
+      )}
+    </>
+  );
 
   return (
     <div
@@ -39,41 +82,45 @@ const TriggerdevFrame = () => {
           <div className={styles.patternBottom} style={{ backgroundImage: `url(${triggerPattern})` }} />
         </>
       )}
-      <div className={styles.window}>
-        <span className={styles.gridlinesHorizontal} data-grid></span>
-        <span className={styles.gridlinesVertical} data-grid></span>
-        {fileName.length > 0 ? (
-          <div className={styles.header}>
-            <div className={classNames(sharedStyles.fileName, styles.fileName)} data-value={fileName}>
-              <input
-                type="text"
-                value={fileName}
-                onChange={(event) => setFileName(event.target.value)}
-                spellCheck={false}
-                tabIndex={-1}
-                size={1}
-              />
+      {isMulti ? (
+        <CodeBlocks windowClassName={styles.window} renderChrome={renderChrome} />
+      ) : (
+        <div className={styles.window}>
+          <span className={styles.gridlinesHorizontal} data-grid></span>
+          <span className={styles.gridlinesVertical} data-grid></span>
+          {fileName.length > 0 ? (
+            <div className={styles.header}>
+              <div className={classNames(sharedStyles.fileName, styles.fileName)} data-value={fileName}>
+                <input
+                  type="text"
+                  value={fileName}
+                  onChange={(event) => setFileName(event.target.value)}
+                  spellCheck={false}
+                  tabIndex={-1}
+                  size={1}
+                />
+              </div>
+              <span className={styles.language}>{selectedLanguage?.name}</span>
             </div>
-            <span className={styles.language}>{selectedLanguage?.name}</span>
-          </div>
-        ) : flashShown ? null : (
-          <div className={styles.header} data-ignore-in-export>
-            <div className={classNames(sharedStyles.fileName, styles.fileName)} data-value={fileName}>
-              <input
-                type="text"
-                value={fileName}
-                onChange={(event) => setFileName(event.target.value)}
-                spellCheck={false}
-                tabIndex={-1}
-                size={1}
-              />
-              <span>Untitled-1</span>
+          ) : flashShown ? null : (
+            <div className={styles.header} data-ignore-in-export>
+              <div className={classNames(sharedStyles.fileName, styles.fileName)} data-value={fileName}>
+                <input
+                  type="text"
+                  value={fileName}
+                  onChange={(event) => setFileName(event.target.value)}
+                  spellCheck={false}
+                  tabIndex={-1}
+                  size={1}
+                />
+                <span>Untitled-1</span>
+              </div>
+              <span className={styles.language}>{selectedLanguage?.name}</span>
             </div>
-            <span className={styles.language}>{selectedLanguage?.name}</span>
-          </div>
-        )}
-        <Editor />
-      </div>
+          )}
+          {primaryBlockId ? <Editor blockId={primaryBlockId} /> : null}
+        </div>
+      )}
     </div>
   );
 };

--- a/app/(navigation)/(code)/components/frames/TriggerdevFrame.tsx
+++ b/app/(navigation)/(code)/components/frames/TriggerdevFrame.tsx
@@ -31,36 +31,20 @@ const TriggerdevFrame = () => {
     <>
       <span className={styles.gridlinesHorizontal} data-grid></span>
       <span className={styles.gridlinesVertical} data-grid></span>
-      {block.title.length > 0 ? (
-        <div className={styles.header}>
-          <div className={classNames(sharedStyles.fileName, styles.fileName)} data-value={block.title}>
-            <input
-              type="text"
-              value={block.title}
-              onChange={(event) => updateBlock({ blockId: block.id, update: { title: event.target.value } })}
-              spellCheck={false}
-              tabIndex={-1}
-              size={1}
-            />
-          </div>
-          <span className={styles.language}>{getBlockLanguage(block)?.name}</span>
+      <div className={styles.header}>
+        <div className={classNames(sharedStyles.fileName, styles.fileName)} data-value={block.title}>
+          <input
+            type="text"
+            value={block.title}
+            onChange={(event) => updateBlock({ blockId: block.id, update: { title: event.target.value } })}
+            spellCheck={false}
+            tabIndex={-1}
+            size={1}
+          />
+          {block.title.length === 0 ? <span data-ignore-in-export>{`Untitled-${index + 1}`}</span> : null}
         </div>
-      ) : flashShown ? null : (
-        <div className={styles.header} data-ignore-in-export>
-          <div className={classNames(sharedStyles.fileName, styles.fileName)} data-value={block.title}>
-            <input
-              type="text"
-              value={block.title}
-              onChange={(event) => updateBlock({ blockId: block.id, update: { title: event.target.value } })}
-              spellCheck={false}
-              tabIndex={-1}
-              size={1}
-            />
-            <span>{`Untitled-${index + 1}`}</span>
-          </div>
-          <span className={styles.language}>{getBlockLanguage(block)?.name}</span>
-        </div>
-      )}
+        <span className={styles.language}>{getBlockLanguage(block)?.name}</span>
+      </div>
     </>
   );
 

--- a/app/(navigation)/(code)/components/frames/VercelFrame.tsx
+++ b/app/(navigation)/(code)/components/frames/VercelFrame.tsx
@@ -4,7 +4,9 @@ import { useAtom, useAtomValue } from "jotai";
 import { showBackgroundAtom } from "../../store";
 import { paddingAtom } from "../../store/padding";
 import { themeDarkModeAtom } from "../../store/themes";
+import { useIsMultiBlock, usePrimaryBlockId } from "../../hooks/usePrimaryBlockId";
 
+import CodeBlocks from "../CodeBlocks";
 import Editor from "../Editor";
 import sharedStyles from "./DefaultFrame.module.css";
 import styles from "./VercelFrame.module.css";
@@ -13,6 +15,8 @@ const VercelFrame = () => {
   const darkMode = useAtomValue(themeDarkModeAtom);
   const [padding] = useAtom(paddingAtom);
   const [showBackground] = useAtom(showBackgroundAtom);
+  const isMulti = useIsMultiBlock();
+  const primaryBlockId = usePrimaryBlockId();
 
   return (
     <div
@@ -26,13 +30,27 @@ const VercelFrame = () => {
       style={{ padding }}
     >
       {!showBackground && <div data-ignore-in-export className={sharedStyles.transparentPattern}></div>}
-      <div className={styles.window}>
-        <span className={styles.gridlinesHorizontal} data-grid></span>
-        <span className={styles.gridlinesVertical} data-grid></span>
-        <span className={styles.bracketLeft} data-grid></span>
-        <span className={styles.bracketRight} data-grid></span>
-        <Editor />
-      </div>
+      {isMulti ? (
+        <CodeBlocks
+          windowClassName={styles.window}
+          renderChrome={() => (
+            <>
+              <span className={styles.gridlinesHorizontal} data-grid />
+              <span className={styles.gridlinesVertical} data-grid />
+              <span className={styles.bracketLeft} data-grid />
+              <span className={styles.bracketRight} data-grid />
+            </>
+          )}
+        />
+      ) : (
+        <div className={styles.window}>
+          <span className={styles.gridlinesHorizontal} data-grid></span>
+          <span className={styles.gridlinesVertical} data-grid></span>
+          <span className={styles.bracketLeft} data-grid></span>
+          <span className={styles.bracketRight} data-grid></span>
+          {primaryBlockId ? <Editor blockId={primaryBlockId} /> : null}
+        </div>
+      )}
     </div>
   );
 };

--- a/app/(navigation)/(code)/hooks/usePrimaryBlockId.ts
+++ b/app/(navigation)/(code)/hooks/usePrimaryBlockId.ts
@@ -1,0 +1,10 @@
+import { useAtomValue } from "jotai";
+import { blocksAtom } from "../store/blocks";
+
+export function usePrimaryBlockId() {
+  return useAtomValue(blocksAtom)[0]?.id ?? null;
+}
+
+export function useIsMultiBlock() {
+  return useAtomValue(blocksAtom).length > 1;
+}

--- a/app/(navigation)/(code)/store/blocks.ts
+++ b/app/(navigation)/(code)/store/blocks.ts
@@ -1,0 +1,259 @@
+import { atom } from "jotai";
+import { Base64 } from "js-base64";
+
+export const MAX_CODE_BLOCKS = 4;
+
+export type CodeBlock = {
+  id: string;
+  title: string;
+  languageKey: string | null;
+  code: string;
+  highlightedLines: number[];
+  detectedLanguageKey?: string | null;
+};
+
+export type PersistedCodeBlock = {
+  id: string;
+  title: string;
+  languageKey: string | null;
+  code: string;
+  highlightedLines: number[];
+};
+
+export function createBlockId() {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID();
+  }
+  return `block-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
+export function createEmptyBlock(overrides: Partial<CodeBlock> = {}): CodeBlock {
+  return {
+    id: createBlockId(),
+    title: "",
+    languageKey: null,
+    code: "",
+    highlightedLines: [],
+    detectedLanguageKey: null,
+    ...overrides,
+  };
+}
+
+function isSSR() {
+  return typeof window === "undefined";
+}
+
+function getHashParams() {
+  return new URLSearchParams(typeof location !== "undefined" ? location.hash.slice(1) : "");
+}
+
+function setHashParams(params: URLSearchParams) {
+  const next = params.toString();
+  const url = new URL(window.location.href);
+  url.hash = next;
+  history.replaceState(null, "", url);
+}
+
+function decodeCodeParam(value: string | null) {
+  if (typeof value !== "string") return null;
+  try {
+    return Base64.decode(value);
+  } catch {
+    console.error("decoding code query parameter failed");
+    return null;
+  }
+}
+
+function readLegacyBlockFromHash(): CodeBlock | null {
+  const params = getHashParams();
+  const code = decodeCodeParam(params.get("code"));
+  if (code === null && !params.get("title") && !params.get("language") && !params.get("highlightedLines")) {
+    return null;
+  }
+
+  const languageKey = params.get("language") || null;
+  const title = params.get("title") || "";
+  const highlightedLines = (params.get("highlightedLines") || "")
+    .split(",")
+    .map(Number)
+    .filter((n) => !Number.isNaN(n) && n > 0);
+
+  return createEmptyBlock({
+    title,
+    languageKey: languageKey || null,
+    code: code ?? "",
+    highlightedLines,
+  });
+}
+
+function readBlocksFromHash(): CodeBlock[] | null {
+  if (isSSR()) return null;
+
+  const params = getHashParams();
+  const raw = params.get("blocks");
+  if (raw) {
+    try {
+      const parsed = JSON.parse(Base64.decode(raw)) as PersistedCodeBlock[];
+      if (Array.isArray(parsed) && parsed.length > 0) {
+        return parsed.slice(0, MAX_CODE_BLOCKS).map((block) =>
+          createEmptyBlock({
+            id: block.id || createBlockId(),
+            title: block.title || "",
+            languageKey: block.languageKey ?? null,
+            code: block.code || "",
+            highlightedLines: Array.isArray(block.highlightedLines) ? block.highlightedLines : [],
+          }),
+        );
+      }
+    } catch (e) {
+      console.error("decoding blocks query parameter failed");
+      console.error(e);
+    }
+  }
+
+  const legacy = readLegacyBlockFromHash();
+  return legacy ? [legacy] : null;
+}
+
+function persistBlocksToHash(blocks: CodeBlock[]) {
+  if (isSSR()) return;
+
+  const params = getHashParams();
+  const persisted: PersistedCodeBlock[] = blocks.map(({ id, title, languageKey, code, highlightedLines }) => ({
+    id,
+    title,
+    languageKey,
+    code,
+    highlightedLines,
+  }));
+
+  if (blocks.length > 1) {
+    params.set("blocks", Base64.encodeURI(JSON.stringify(persisted)));
+  } else {
+    params.delete("blocks");
+  }
+
+  const primary = blocks[0];
+  if (primary) {
+    if (primary.code) {
+      params.set("code", Base64.encodeURI(primary.code));
+    } else {
+      params.delete("code");
+    }
+
+    if (primary.languageKey) {
+      params.set("language", primary.languageKey);
+    } else {
+      params.delete("language");
+    }
+
+    if (primary.title) {
+      params.set("title", primary.title);
+    } else {
+      params.delete("title");
+    }
+
+    if (primary.highlightedLines.length > 0) {
+      params.set("highlightedLines", primary.highlightedLines.join(","));
+    } else {
+      params.delete("highlightedLines");
+    }
+  }
+
+  setHashParams(params);
+}
+
+const initialBlocks = readBlocksFromHash();
+
+export const blocksAtom = atom<CodeBlock[]>(initialBlocks ?? [createEmptyBlock()]);
+
+blocksAtom.onMount = (setBlocks) => {
+  const fromHash = readBlocksFromHash();
+  if (fromHash) {
+    setBlocks(fromHash);
+  }
+};
+
+export const activeBlockIdAtom = atom<string | null>(null);
+
+export const resolvedActiveBlockIdAtom = atom((get) => {
+  const blocks = get(blocksAtom);
+  const activeId = get(activeBlockIdAtom);
+  if (activeId && blocks.some((block) => block.id === activeId)) {
+    return activeId;
+  }
+  return blocks[0]?.id ?? null;
+});
+
+export const activeBlockAtom = atom(
+  (get) => {
+    const blocks = get(blocksAtom);
+    const activeId = get(resolvedActiveBlockIdAtom);
+    return blocks.find((block) => block.id === activeId) ?? blocks[0];
+  },
+  (get, set, update: Partial<CodeBlock>) => {
+    const activeId = get(resolvedActiveBlockIdAtom);
+    if (!activeId) return;
+
+    const next = get(blocksAtom).map((block) => (block.id === activeId ? { ...block, ...update } : block));
+    set(blocksAtom, next);
+    persistBlocksToHash(next);
+  },
+);
+
+export const updateBlockAtom = atom(null, (get, set, payload: { blockId: string; update: Partial<CodeBlock> }) => {
+  const next = get(blocksAtom).map((block) => (block.id === payload.blockId ? { ...block, ...payload.update } : block));
+  set(blocksAtom, next);
+  persistBlocksToHash(next);
+});
+
+export const setBlocksAndPersistAtom = atom(null, (get, set, next: CodeBlock[]) => {
+  const limited = next.slice(0, MAX_CODE_BLOCKS);
+  set(blocksAtom, limited);
+  if (!limited.some((block) => block.id === get(activeBlockIdAtom))) {
+    set(activeBlockIdAtom, limited[0]?.id ?? null);
+  }
+  persistBlocksToHash(limited);
+});
+
+export const addBlockAtom = atom(null, (get, set, seedFirstBlock?: Partial<CodeBlock>) => {
+  const blocks = get(blocksAtom);
+  if (blocks.length >= MAX_CODE_BLOCKS) return;
+
+  const nextBlock = createEmptyBlock({
+    title: "",
+    code: "",
+  });
+
+  let base = blocks;
+  if (seedFirstBlock && blocks[0]) {
+    base = [{ ...blocks[0], ...seedFirstBlock }, ...blocks.slice(1)];
+  }
+
+  const next = [...base, nextBlock];
+  set(blocksAtom, next);
+  set(activeBlockIdAtom, nextBlock.id);
+  persistBlocksToHash(next);
+});
+
+export const removeBlockAtom = atom(null, (get, set, blockId: string) => {
+  const blocks = get(blocksAtom);
+  if (blocks.length <= 1) return;
+
+  const index = blocks.findIndex((block) => block.id === blockId);
+  const next = blocks.filter((block) => block.id !== blockId);
+  set(blocksAtom, next);
+
+  if (get(activeBlockIdAtom) === blockId) {
+    const fallback = next[Math.max(0, index - 1)] ?? next[0];
+    set(activeBlockIdAtom, fallback?.id ?? null);
+  }
+
+  persistBlocksToHash(next);
+});
+
+export const totalCodeAtom = atom((get) =>
+  get(blocksAtom)
+    .map((block) => block.code)
+    .join("\n"),
+);

--- a/app/(navigation)/(code)/store/code.ts
+++ b/app/(navigation)/(code)/store/code.ts
@@ -1,8 +1,15 @@
 import { atom } from "jotai";
-import { Base64 } from "js-base64";
 import hljs from "highlight.js";
-import { atomWithHash } from "jotai-location";
 import { LANGUAGES, Language } from "../util/languages";
+import {
+  activeBlockAtom,
+  blocksAtom,
+  createEmptyBlock,
+  resolvedActiveBlockIdAtom,
+  setBlocksAndPersistAtom,
+  updateBlockAtom,
+  type CodeBlock,
+} from "./blocks";
 
 type CodeSample = {
   language: Language;
@@ -61,102 +68,104 @@ const detectLanguage: (input: string) => Promise<string> = async (input) => {
   });
 };
 
-export const autoDetectLanguageAtom = atom<boolean>((get) => {
-  return get(userInputtedLanguageAtom) === null;
-});
-
-const detectedLanguageAtom = atom<Language | null>(null);
-const userInputtedLanguageAtom = atomWithHash<Language | null>("language", null, {
-  serialize(language) {
-    const key = Object.keys(LANGUAGES).find((key) => LANGUAGES[key] === language);
-
-    if (key) {
-      return key;
-    } else {
-      return "";
-    }
-  },
-  deserialize(key) {
-    if (key && LANGUAGES[key]) {
-      return LANGUAGES[key];
-    } else {
-      return null;
-    }
-  },
-});
-
-export const selectedLanguageAtom = atom(
-  (get) => {
-    if (get(userInputtedLanguageAtom) === null) {
-      const codeSampleValue = get(codeExampleAtom);
-      if (get(userInputtedCodeAtom) === null && codeSampleValue) {
-        return codeSampleValue.language;
-      } else {
-        return get(detectedLanguageAtom);
-      }
-    } else {
-      return get(userInputtedLanguageAtom);
-    }
-  },
-  (get, set, newLanguage: Language | null) => {
-    set(userInputtedLanguageAtom, newLanguage);
-  },
-);
+function getLanguageKey(language: Language | null) {
+  if (!language) return null;
+  return Object.keys(LANGUAGES).find((key) => LANGUAGES[key] === language) ?? null;
+}
 
 export const codeExampleAtom = atom<CodeSample | null>(CODE_SAMPLES[Math.floor(Math.random() * CODE_SAMPLES.length)]);
 
-export const isCodeExampleAtom = atom<boolean>(
-  (get) => !!CODE_SAMPLES.find((codeSample) => codeSample.code === get(codeAtom)),
-);
-
-const isSSR = () => typeof window === "undefined";
-
-function getUserInputtedCodeFromHash() {
-  const searchParams = new URLSearchParams(location.hash.slice(1));
-  const searchParamsCode = searchParams.get("code");
-
-  if (typeof searchParamsCode === "string") {
-    try {
-      const code = Base64.decode(searchParamsCode);
-      return code;
-    } catch (e) {
-      console.error("decoding code query parameter failed");
-      console.error(e);
-    }
-  }
-
-  return null;
+function hasPersistedCode(blocks: CodeBlock[]) {
+  return blocks.some((block) => block.code.length > 0);
 }
-
-function getInitialUserInputtedCode() {
-  if (isSSR()) {
-    return null;
-  } else {
-    return getUserInputtedCodeFromHash();
-  }
-}
-
-export const userInputtedCodeAtom = atom<string | null>(getInitialUserInputtedCode());
 
 export const codeAtom = atom(
-  (get) => get(userInputtedCodeAtom) ?? get(codeExampleAtom)?.code ?? "",
-  (get, set, newCode: string) => {
-    const searchParams = new URLSearchParams(location.hash.slice(1));
-    set(userInputtedCodeAtom, newCode);
+  (get) => {
+    const block = get(activeBlockAtom);
+    if (!block) return "";
 
-    searchParams.set("code", Base64.encodeURI(newCode));
-    window.location.hash = `#${searchParams.toString()}`;
+    if (!hasPersistedCode(get(blocksAtom))) {
+      return get(codeExampleAtom)?.code ?? "";
+    }
+
+    return block.code;
+  },
+  (get, set, newCode: string) => {
+    const activeId = get(resolvedActiveBlockIdAtom);
+    if (!activeId) return;
+
+    const blocks = get(blocksAtom);
+    const showingExample = !hasPersistedCode(blocks);
+
+    if (showingExample) {
+      const example = get(codeExampleAtom);
+      set(setBlocksAndPersistAtom, [
+        createEmptyBlock({
+          id: activeId,
+          code: newCode,
+          languageKey: null,
+          detectedLanguageKey: getLanguageKey(example?.language ?? null),
+        }),
+      ]);
+    } else {
+      set(updateBlockAtom, { blockId: activeId, update: { code: newCode } });
+    }
 
     detectLanguage(newCode).then((language) => {
       if (LANGUAGES[language]) {
-        set(detectedLanguageAtom, LANGUAGES[language]);
+        set(updateBlockAtom, { blockId: activeId, update: { detectedLanguageKey: language } });
       }
     });
   },
 );
 
-codeAtom.onMount = (setValue) => {
-  const code = getUserInputtedCodeFromHash();
+export const isCodeExampleAtom = atom<boolean>((get) => {
+  const code = get(codeAtom);
+  return !hasPersistedCode(get(blocksAtom)) && !!CODE_SAMPLES.find((codeSample) => codeSample.code === code);
+});
 
-  if (code) setValue(code);
-};
+export const autoDetectLanguageAtom = atom<boolean>((get) => {
+  const block = get(activeBlockAtom);
+  return block?.languageKey == null;
+});
+
+export const selectedLanguageAtom = atom(
+  (get) => {
+    const block = get(activeBlockAtom);
+    if (!block) return null;
+
+    if (block.languageKey && LANGUAGES[block.languageKey]) {
+      return LANGUAGES[block.languageKey];
+    }
+
+    if (get(isCodeExampleAtom)) {
+      return get(codeExampleAtom)?.language ?? null;
+    }
+
+    if (block.detectedLanguageKey && LANGUAGES[block.detectedLanguageKey]) {
+      return LANGUAGES[block.detectedLanguageKey];
+    }
+
+    return null;
+  },
+  (get, set, newLanguage: Language | null) => {
+    set(activeBlockAtom, { languageKey: getLanguageKey(newLanguage) });
+  },
+);
+
+export function getBlockLanguage(block: {
+  languageKey: string | null;
+  detectedLanguageKey?: string | null;
+}): Language | null {
+  if (block.languageKey && LANGUAGES[block.languageKey]) {
+    return LANGUAGES[block.languageKey];
+  }
+  if (block.detectedLanguageKey && LANGUAGES[block.detectedLanguageKey]) {
+    return LANGUAGES[block.detectedLanguageKey];
+  }
+  return null;
+}
+
+export function detectBlockLanguage(code: string) {
+  return detectLanguage(code);
+}

--- a/app/(navigation)/(code)/store/index.ts
+++ b/app/(navigation)/(code)/store/index.ts
@@ -1,6 +1,7 @@
 import { atom } from "jotai";
 import { atomWithHash } from "jotai-location";
 import type { Highlighter } from "shiki";
+import { blocksAtom, updateBlockAtom } from "./blocks";
 
 export const windowWidthAtom = atomWithHash<number | null>("width", null);
 
@@ -8,14 +9,14 @@ export const showBackgroundAtom = atomWithHash<boolean>("background", true);
 
 export const showLineNumbersAtom = atomWithHash<boolean | undefined>("lineNumbers", undefined);
 
-export const fileNameAtom = atomWithHash<string>("title", "", {
-  serialize(val) {
-    return val;
+export const fileNameAtom = atom(
+  (get) => get(blocksAtom)[0]?.title ?? "",
+  (get, set, title: string) => {
+    const first = get(blocksAtom)[0];
+    if (!first) return;
+    set(updateBlockAtom, { blockId: first.id, update: { title } });
   },
-  deserialize(str) {
-    return str || "";
-  },
-});
+);
 
 export const subtitleAtom = atomWithHash<string>("subtitle", "", {
   serialize(val) {
@@ -29,12 +30,3 @@ export const subtitleAtom = atomWithHash<string>("subtitle", "", {
 export const highlighterAtom = atom<Highlighter | null>(null);
 
 export const loadingLanguageAtom = atom<boolean>(false);
-
-export const highlightedLinesAtom = atomWithHash<number[]>("highlightedLines", [], {
-  serialize(val) {
-    return val.join(",");
-  },
-  deserialize(str) {
-    return str ? str.split(",").map(Number) : [];
-  },
-});


### PR DESCRIPTION
Adds support for rendering multiple code blocks with independent syntax highlighting languages.
Fixes #459

https://github.com/user-attachments/assets/292ef6d6-b8a7-43a0-ae62-3918bcae0390

### Editor
<img width="1920" height="993" alt="image" src="https://github.com/user-attachments/assets/6045a338-d0ee-4152-a8d8-096641e32a1f" />

### Export
<img width="2080" height="2624" alt="Factorial (5)" src="https://github.com/user-attachments/assets/f533f75d-7e6c-4d48-be30-1bc4b0f5922f" />

### Changes Summary

- Add multi-block code screenshots: stack up to 4 theme windows in one export, each with its own title, language, and highlighted lines
- Preserve original single-block theme chrome; multi only appends whole windows (no shared fake header)
- Add a floating + on the controls panel edge to add blocks; per-window delete on hover; language/format apply to the active block
- Persist multi-block state in the URL hash (blocks) while keeping legacy single-block params for back-compat
- Always show language labels on multi-block Cloudflare / Trigger.dev windows even when the title is empty